### PR TITLE
Add notes on how to build the project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,27 @@
-We are currently working on improving the contributor experience.  Bug fixes and new features must be submitted using a pull request.
+# Submitting bugs and fixes
+Open an issue detailing the issue you've encountered or feature you would like to see.
 
+Bug fixes and new features must be submitted using a pull request and pass CI to be included in the project.
+
+## Building the project locally
+
+Requires [.NET 8+](https://dotnet.microsoft.com/en-us/download)
+
+```
+dotnet msbuild src/WasmComponent.Sdk/build/WasmComponent.Sdk.targets /t:PrepareWasmSdks
+git submodule update --init
+dotnet build
+```
+
+If you are experiencing issues with values not being updated, try running `dotnet clean` and using the steps above
+
+## Testing
+
+Run the tests:
+
+```
+dotnet test
+```
+
+## Getting help
 While we work on improving the documentation for contributing, if you have any questions please drop a note in the [c# zulip chat](https://bytecodealliance.zulipchat.com/#narrow/stream/407028-C.23.2F.2Enet-collaboration).

--- a/README.md
+++ b/README.md
@@ -205,3 +205,6 @@ This is a wrapper around various other bits of tooling:
  * [WASI SDK](https://github.com/WebAssembly/wasi-sdk) and [Emscripten](https://emscripten.org/), both of which are used by NativeAOT-LLVM.
    * Compatible versions of these will be downloaded and cached on your machine the first time you run a build, so the first build will take a few minutes. After that it will only take seconds.
 
+## Contributing
+
+See our [contributing docs](./CONTRIBUTING.md) for details on how to build and contribute to this project.

--- a/src/WasmComponent.Sdk/build/WasmComponent.Sdk.targets
+++ b/src/WasmComponent.Sdk/build/WasmComponent.Sdk.targets
@@ -14,7 +14,9 @@
 
         <EmSdkVersion>3.1.23</EmSdkVersion>
         <EmSdkUrl>https://github.com/emscripten-core/emsdk/archive/refs/tags/$(EmSdkVersion).zip</EmSdkUrl>
-        <EmscriptenRoot>$([System.IO.Path]::Combine("$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))", ".emsdk", "emsdk-$(EmSdkVersion)"))</EmscriptenRoot>
+        <!-- Support bring your own emscripten if $(EMSDK) is already set-->
+        <EmscriptenRoot Condition="'$(EMSDK)' == ''">$([System.IO.Path]::Combine("$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))", ".emsdk", "emsdk-$(EmSdkVersion)"))</EmscriptenRoot>
+        <EmscriptenRoot Condition="'$(EMSDK)' != ''">$(EMSDK)</EmscriptenRoot> 
     </PropertyGroup>
 
     <Target Name="EmitWasmOnBuild" AfterTargets="CopyFilesToOutputDirectory" DependsOnTargets="LinkNativeLlvm; ConvertToWasmComponent"


### PR DESCRIPTION
This adds notes on how to build and test the project. It also fixes a bug when you already have the `$(EMSDK)` value set in your path.