### PR TITLE
Update Wit-bindgen, related tools and make tests pass

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        submodules: 'true'
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
@@ -25,7 +23,7 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Prepare WASM SDKs
-      run: dotnet msbuild src/WasmComponent.Sdk/build/WasmComponent.Sdk.targets /t:PrepareWasmSdks
+      run: dotnet msbuild src/WitBindgen/build/WitBindgen.targets /t:PrepareWasmSdks
     - name: Build
       run: dotnet build --no-restore /p:BuildNumber=${{ github.run_number }}
     - name: Test

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "modules/wit-bindgen"]
 	path = modules/wit-bindgen
-	url = https://github.com/jsturtevant/wit-bindgen.git
+	url = https://github.com/bytecodealliance/wit-bindgen.git
 [submodule "modules/wasm-tools"]
 	path = modules/wasm-tools
-	url = https://github.com/dicej/wasm-tools.git
+	url = https://github.com/bytecodealliance/wasm-tools.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,17 +3,15 @@ Open an issue detailing the issue you've encountered or feature you would like t
 
 Bug fixes and new features must be submitted using a pull request and pass CI to be included in the project.
 
-## Building the project locally
+## Building
 
 Requires [.NET 8+](https://dotnet.microsoft.com/en-us/download)
 
 ```
-dotnet msbuild src/WasmComponent.Sdk/build/WasmComponent.Sdk.targets /t:PrepareWasmSdks
-git submodule update --init
+## needed to avoid errors with multiple projects calling and downloading the sdks at same time (https://github.com/bytecodealliance/componentize-dotnet/issues/8)
+dotnet msbuild src/WitBindgen/build/WitBindgen.targets /t:PrepareWasmSdks
 dotnet build
 ```
-
-If you are experiencing issues with values not being updated, try running `dotnet clean` and using the steps above
 
 ## Testing
 
@@ -23,5 +21,59 @@ Run the tests:
 dotnet test
 ```
 
+>  tip: If you've already built the project you can speed up the tests by running `dotnet test --no-build`
+
+## Build Wasm tools locally
+
+> requires [rust](https://www.rust-lang.org/tools/install)
+
+The project is configured by default to pull tools such as [wit-bindgen](https://github.com/bytecodealliance/wit-bindgen) from their releases.  It is possible to use custom builds of these tools via submodules:
+
+```
+## get submodules
+git submodule update --int
+
+## get latest code from configured branch
+git submodule update --recursive --remote
+
+## optional, change the branch for the project
+cd modules/<project>
+git checkout <branch>
+```
+
+Modify the [WasmComponentSdk.csproj](./src/WasmComponent.Sdk/WasmComponent.Sdk.csproj) to enable building from source:
+
+```
+<BuildWasmToolsLocally>true</BuildWasmToolsLocally>
+```
+
+Modify the [WitBindgen.csproj](./src/WitBindgen/WitBindgen.csproj) to enable building from source:
+
+```
+<BuildWitBindgenLocally>true</BuildWitBindgenLocally>
+```
+
+And then follow the [project build steps](#building).
+
+### Debugging
+
+Create a msbuild debug log: 
+
+```
+dotnet build /bl
+```
+
+View the log with https://www.msbuildlog.com/.
+
+Learn more at [trouble shooting techniques](https://learn.microsoft.com/en-us/visualstudio/ide/msbuild-logs?view=vs-2022) for msbuild.
+
 ## Getting help
-While we work on improving the documentation for contributing, if you have any questions please drop a note in the [c# zulip chat](https://bytecodealliance.zulipchat.com/#narrow/stream/407028-C.23.2F.2Enet-collaboration).
+
+> If you have any questions please drop a note in the [c# zulip chat](https://bytecodealliance.zulipchat.com/#narrow/stream/407028-C.23.2F.2Enet-collaboration).
+
+This project uses MSbuild and .NET Project SDKS.  Learn more about this tooling in:
+
+- [MSbuild docs](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild?view=vs-2022)
+- [.NET Project SDKS](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/overview)
+- [Creating Reliable Builds](https://learn.microsoft.com/en-us/archive/msdn-magazine/2009/february/msbuild-best-practices-for-creating-reliable-builds-part-1#id0090093)
+

--- a/samples/calculator/Adder/OperationsImpl.cs
+++ b/samples/calculator/Adder/OperationsImpl.cs
@@ -1,6 +1,6 @@
-﻿namespace wit_computer.Wit.exports.example.calculator.Operations;
+﻿namespace ComputerWorld.wit.exports.example.calculator;
 
-public class OperationsImpl : Operations
+public class OperationsImpl : IOperations
 {
     public static int Add(int left, int right)
     {

--- a/samples/calculator/CalculatorComposed/CalculatorComposed.csproj
+++ b/samples/calculator/CalculatorComposed/CalculatorComposed.csproj
@@ -17,8 +17,8 @@
 
     <Target Name="ComposeWasmComponent" AfterTargets="Build">
         <PropertyGroup>
-            <EntrypointComponent>../CalculatorHost/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/CalculatorHost.component.wasm</EntrypointComponent>
-            <DependencyComponent>../Adder/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/Adder.component.wasm</DependencyComponent>
+            <EntrypointComponent>../CalculatorHost/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/calculatorhost-component.wasm</EntrypointComponent>
+            <DependencyComponent>../Adder/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/adder-component.wasm</DependencyComponent>
         </PropertyGroup>
         
         <MakeDir Directories="dist" />

--- a/samples/calculator/CalculatorHost/Program.cs
+++ b/samples/calculator/CalculatorHost/Program.cs
@@ -1,4 +1,4 @@
-﻿using wit_hostapp.Wit.imports.example.calculator.Operations;
+﻿using HostappWorld.wit.imports.example.calculator;
 
 var left = 123;
 var right = 456;

--- a/src/WasmComponent.Sdk/WasmComponent.Sdk.csproj
+++ b/src/WasmComponent.Sdk/WasmComponent.Sdk.csproj
@@ -9,10 +9,10 @@
 
         <!-- Things you might want to edit -->
         <!-- Set BuildWasmToolsLocally to true if you want to build modules/wasm-tools locally and use its output -->
-        <BuildWasmToolsLocally>true</BuildWasmToolsLocally>
-        <PrebuiltWasmToolsVersion>1.0.51</PrebuiltWasmToolsVersion>
-        <PrebuiltWasmToolsBaseUrl>https://github.com/bytecodealliance/wasm-tools/releases/download/wasm-tools-$(PrebuiltWasmToolsVersion)/wasm-tools-$(PrebuiltWasmToolsVersion)</PrebuiltWasmToolsBaseUrl>
-        <WasmtimeVersionForWasiSnapshotPreview1Adapters>14.0.4</WasmtimeVersionForWasiSnapshotPreview1Adapters>
+        <BuildWasmToolsLocally>false</BuildWasmToolsLocally>
+        <PrebuiltWasmToolsVersion>1.209.1</PrebuiltWasmToolsVersion>
+        <PrebuiltWasmToolsBaseUrl>https://github.com/bytecodealliance/wasm-tools/releases/download/v$(PrebuiltWasmToolsVersion)/wasm-tools-$(PrebuiltWasmToolsVersion)</PrebuiltWasmToolsBaseUrl>
+        <WasmtimeVersionForWasiSnapshotPreview1Adapters>21.0.1</WasmtimeVersionForWasiSnapshotPreview1Adapters>
 
         <WasmToolsModuleRoot>$(MSBuildThisFileDirectory)..\..\modules\wasm-tools\</WasmToolsModuleRoot>
 
@@ -68,13 +68,10 @@
         <RemoveDir Directories="tools\temp" />
     </Target>
 
-    <Target Name="DownloadWasiPreview1Adapters" Condition="!Exists('tools\wasi-wasm\lastbuild.txt')">
+    <Target Name="DownloadWasiPreview1Adapters" Inputs="$(MSBuildThisFileDirectory)tools\wasi-wasm\version" Outputs="$(MSBuildThisFileDirectory)tools\wasi-wasm\version" >
         <DownloadFile SourceUrl="https://github.com/bytecodealliance/wasmtime/releases/download/v$(WasmtimeVersionForWasiSnapshotPreview1Adapters)/wasi_snapshot_preview1.command.wasm" DestinationFolder="tools\wasi-wasm" />
         <DownloadFile SourceUrl="https://github.com/bytecodealliance/wasmtime/releases/download/v$(WasmtimeVersionForWasiSnapshotPreview1Adapters)/wasi_snapshot_preview1.reactor.wasm" DestinationFolder="tools\wasi-wasm" />
-        <WriteLinesToFile File="tools\wasi-wasm\lastbuild.txt" Lines="" Overwrite="true" />
-        <ItemGroup>
-            <FileWrites Include="tools\wasi-wasm\lastbuild.txt" />
-        </ItemGroup>
+        <WriteLinesToFile File="$(MSBuildThisFileDirectory)tools\wasi-wasm\version" Lines="$(WasmtimeVersionForWasiSnapshotPreview1Adapters)" Overwrite="true"  WriteOnlyWhenDifferent="true" />
     </Target>
 
     <Target Name="PackTaskDependencies" BeforeTargets="GenerateNuspec">

--- a/src/WasmComponent.Sdk/build/WasmComponent.Sdk.targets
+++ b/src/WasmComponent.Sdk/build/WasmComponent.Sdk.targets
@@ -33,7 +33,11 @@
             <WasiPreview1AdapterType>reactor</WasiPreview1AdapterType>
             <WasiPreview1AdapterType Condition="'$(OutputType.ToLower())' == 'exe'">command</WasiPreview1AdapterType>
             <WasiPreview1AdapterPath>$(MSBuildThisFileDirectory)../tools/wasi-wasm/wasi_snapshot_preview1.$(WasiPreview1AdapterType).wasm</WasiPreview1AdapterPath>
-            <NativeComponentBinary>$(NativeOutputPath)$(TargetName).component.wasm</NativeComponentBinary>
+            <!-- 
+                wasm compose requires kabab case (todo: revisit when move to wac https://github.com/bytecodealliance/componentize-dotnet/issues/5) 
+                https://github.com/bytecodealliance/wasm-tools/issues/1440
+            -->
+            <NativeComponentBinary>$(NativeOutputPath)$(TargetName.ToLower())-component.wasm</NativeComponentBinary>
         </PropertyGroup>
     </Target>
 

--- a/src/WasmComponent.Sdk/build/WasmComponent.Sdk.targets
+++ b/src/WasmComponent.Sdk/build/WasmComponent.Sdk.targets
@@ -1,24 +1,4 @@
 <Project>
-    <!--
-    MSBuild stuff to acquire the necessary SDKs (WASI SDK and Emscripten) automatically. It will take a few mins on the
-    first build on a given machine, but after that should no-op.
-    -->
-
-    <PropertyGroup>
-        <!-- Keep this block all in sync manually, since URLs can be arbitrary -->
-        <WasiSdkVersion>20.0</WasiSdkVersion>
-        <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('Windows'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0.m-mingw.tar.gz</WasiSdkUrl>
-        <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('Linux'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0-linux.tar.gz</WasiSdkUrl>
-        <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('OSX'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0-macos.tar.gz</WasiSdkUrl>
-        <WasiSdkRoot>$([System.IO.Path]::Combine("$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))", ".wasi-sdk", "wasi-sdk-$(WasiSdkVersion)"))</WasiSdkRoot>
-
-        <EmSdkVersion>3.1.23</EmSdkVersion>
-        <EmSdkUrl>https://github.com/emscripten-core/emsdk/archive/refs/tags/$(EmSdkVersion).zip</EmSdkUrl>
-        <!-- Support bring your own emscripten if $(EMSDK) is already set-->
-        <EmscriptenRoot Condition="'$(EMSDK)' == ''">$([System.IO.Path]::Combine("$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))", ".emsdk", "emsdk-$(EmSdkVersion)"))</EmscriptenRoot>
-        <EmscriptenRoot Condition="'$(EMSDK)' != ''">$(EMSDK)</EmscriptenRoot> 
-    </PropertyGroup>
-
     <Target Name="EmitWasmOnBuild" AfterTargets="CopyFilesToOutputDirectory" DependsOnTargets="LinkNativeLlvm; ConvertToWasmComponent"
             Condition="'$(RuntimeIdentifier)' == 'wasi-wasm'">
         <Message Importance="high" Text="$(ProjectName) -> $([System.IO.Path]::GetFullPath('$(NativeComponentBinary)'))" />
@@ -39,64 +19,5 @@
             -->
             <NativeComponentBinary>$(NativeOutputPath)$(TargetName.ToLower())-component.wasm</NativeComponentBinary>
         </PropertyGroup>
-    </Target>
-
-    <Target Name="PrepareWasmSdks" BeforeTargets="CheckWasmSdks" DependsOnTargets="ObtainWasiSdk; ObtainEmscripten">
-        <PropertyGroup>
-            <EmSdk>$(EmscriptenRoot)</EmSdk>
-            <WASI_SDK_PATH>$(WasiSdkRoot)</WASI_SDK_PATH>
-        </PropertyGroup>
-    </Target>
-
-    <Target Name="ObtainEmscripten" Condition="'$(EMSDK)' == '' AND !(Exists($(EmscriptenRoot)))">
-        <!--
-            This is not ideal because if your solution has multiple projects that use WasmComponent.Sdk, then if you
-            build in parallel in CI where your machine doesn't already have wasi-sdk/emsdk, then it may try to download
-            and extract the SDKs multiple times in parallel to the same disk location, which may cause it to fail.
-            The only reason this doesn't happen in this repo is that it explicitly runs the PrepareWasmSdks task before
-            building other projects.
-
-            For a proper fix, consider implementing an MSBuild task in C# that obtains wasi-sdk/emsdk, and uses a mutex
-            so that only one flow executes at a time, with others blocking until it's done.
-        -->
-
-        <PropertyGroup>
-            <EmSdkDownloadTempDir>$([System.IO.Path]::Combine($([System.IO.Path]::GetTempPath()), $([System.IO.Path]::GetRandomFileName())))</EmSdkDownloadTempDir>
-        </PropertyGroup>
-
-        <MakeDir Directories="$(EmSdkDownloadTempDir)" />
-        <DownloadFile
-            SourceUrl="$(EmSdkUrl)"
-            DestinationFolder="$(EmSdkDownloadTempDir)">
-            <Output TaskParameter="DownloadedFile" ItemName="EmSdkDownloadTempFile" />
-        </DownloadFile>
-
-        <!-- Windows 10+ has tar built in, so this should work cross-platform -->
-        <Message Importance="high" Text="Extracting @(EmSdkDownloadTempFile) to $(EmscriptenRoot)..." />
-        <MakeDir Directories="$(EmscriptenRoot)" />
-        <Exec Command="tar -xf &quot;@(EmSdkDownloadTempFile)&quot; -C . --strip-components=1" WorkingDirectory="$(EmscriptenRoot)" />
-        <RemoveDir Directories="$(EmSdkDownloadTempDir)" />
-
-        <Exec Command="emsdk install $(EmSdkVersion)" WorkingDirectory="$(EmscriptenRoot)" />
-        <Exec Command="emsdk activate $(EmSdkVersion)" WorkingDirectory="$(EmscriptenRoot)" />
-    </Target>
-
-    <Target Name="ObtainWasiSdk" Condition="!(Exists($(WasiSdkRoot)))">
-        <PropertyGroup>
-            <WasiSdkDownloadTempDir>$([System.IO.Path]::Combine($([System.IO.Path]::GetTempPath()), $([System.IO.Path]::GetRandomFileName())))</WasiSdkDownloadTempDir>
-        </PropertyGroup>
-
-        <MakeDir Directories="$(WasiSdkDownloadTempDir)" />
-        <DownloadFile
-            SourceUrl="$(WasiSdkUrl)"
-            DestinationFolder="$(WasiSdkDownloadTempDir)">
-            <Output TaskParameter="DownloadedFile" ItemName="WasiSdkDownloadTempFile" />
-        </DownloadFile>
-
-        <!-- Windows 10+ has tar built in, so this should work cross-platform -->
-        <Message Importance="high" Text="Extracting @(WasiSdkDownloadTempFile) to $(WasiSdkRoot)..." />
-        <MakeDir Directories="$(WasiSdkRoot)" />
-        <Exec Command="tar -xf &quot;@(WasiSdkDownloadTempFile)&quot; -C . --strip-components=1" WorkingDirectory="$(WasiSdkRoot)" />
-        <RemoveDir Directories="$(WasiSdkDownloadTempDir)" />
     </Target>
 </Project>

--- a/src/WitBindgen/WitBindgen.csproj
+++ b/src/WitBindgen/WitBindgen.csproj
@@ -9,11 +9,13 @@
 
         <!-- Things you might want to edit -->
         <!-- Set BuildWitBindgenLocally to true if you want to build modules/wit-bindgen locally and use its output -->
-        <BuildWitBindgenLocally>true</BuildWitBindgenLocally>
-        <PrebuiltWitBindgenVersion>0.14.0</PrebuiltWitBindgenVersion>
-        <PrebuiltWitBindgenBaseUrl>https://github.com/bytecodealliance/wit-bindgen/releases/download/wit-bindgen-cli-$(PrebuiltWitBindgenVersion)/wit-bindgen-v$(PrebuiltWitBindgenVersion)</PrebuiltWitBindgenBaseUrl>
-
+        <BuildWitBindgenLocally>false</BuildWitBindgenLocally>
+        <PrebuiltWitBindgenVersion>0.26.0</PrebuiltWitBindgenVersion>
+        <PrebuiltWitBindgenBaseUrl>https://github.com/bytecodealliance/wit-bindgen/releases/download/v$(PrebuiltWitBindgenVersion)/wit-bindgen-$(PrebuiltWitBindgenVersion)</PrebuiltWitBindgenBaseUrl>
         <WitBindgenModuleRoot>$(MSBuildThisFileDirectory)..\..\modules\wit-bindgen\</WitBindgenModuleRoot>
+
+        <!-- This is a marker file that lets the build scripts identity if the files need to be modified when updating versions -->
+        <CurrentWitBindgenVersion>$(MSBuildThisFileDirectory)tools\version-$(PrebuiltWitBindgenVersion)</CurrentWitBindgenVersion>
 
         <!-- Don't pack any assemblies in lib/*/.dll.-->
         <NoPackageAnalysis>true</NoPackageAnalysis>
@@ -50,8 +52,10 @@
         </ItemGroup>
     </Target>
 
-    <Target Name="DownloadNativeToolingCore" Inputs="@(PrebuiltWitBindgenOutputs)" Outputs="@(PrebuiltWitBindgenOutputs)">
+    <Target  Name="DownloadNativeToolingCore" Condition="!Exists('$(CurrentWitBindgenVersion)')" Inputs="@(PrebuiltWitBindgenOutputs);$(CurrentWitBindgenVersion)" Outputs="@(PrebuiltWitBindgenOutputs);$(CurrentWitBindgenVersion)">
+        <RemoveDir Directories="$(MSBuildThisFileDirectory)tools" />
         <DownloadFile SourceUrl="$(PrebuiltWitBindgenBaseUrl)-%(PrebuiltWitBindgenToolTarget.Identity)%(PrebuiltWitBindgenToolTarget.Ext)" DestinationFolder="tools\temp" DestinationFileName="%(PrebuiltWitBindgenToolTarget.Rid)%(PrebuiltWitBindgenToolTarget.Ext)" />
+        <WriteLinesToFile File="$(CurrentWitBindgenVersion)" Lines="$(PrebuiltWitBindgenVersion)" Overwrite="true" WriteOnlyWhenDifferent="true" />
         <MakeDir Directories="tools\%(PrebuiltWitBindgenToolTarget.Rid)" />
         <Exec Command="tar -xf &quot;temp/%(PrebuiltWitBindgenToolTarget.Rid)%(PrebuiltWitBindgenToolTarget.Ext)&quot; -C %(PrebuiltWitBindgenToolTarget.Rid) --strip-components=1" WorkingDirectory="tools" />
         <RemoveDir Directories="tools\temp" />

--- a/src/WitBindgen/build/WitBindgen.targets
+++ b/src/WitBindgen/build/WitBindgen.targets
@@ -1,11 +1,91 @@
 ﻿<Project>
     <PropertyGroup>
         <WitBindgenRuntime>native-aot</WitBindgenRuntime>
+
+        <!-- Keep this block all in sync manually, since URLs can be arbitrary -->
+        <WasiSdkVersion>20.0</WasiSdkVersion>
+        <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('Windows'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0.m-mingw.tar.gz</WasiSdkUrl>
+        <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('Linux'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0-linux.tar.gz</WasiSdkUrl>
+        <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('OSX'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0-macos.tar.gz</WasiSdkUrl>
+        <WasiSdkRoot>$([System.IO.Path]::Combine("$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))", ".wasi-sdk", "wasi-sdk-$(WasiSdkVersion)"))</WasiSdkRoot>
+
+        <EmSdkVersion>3.1.61</EmSdkVersion>
+        <EmSdkUrl>https://github.com/emscripten-core/emsdk/archive/refs/tags/$(EmSdkVersion).zip</EmSdkUrl>
+        <!-- Support bring your own emscripten if $(EMSDK) is already set-->
+        <EmscriptenRoot Condition="'$(EMSDK)' == ''">$([System.IO.Path]::Combine("$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))", ".emsdk", "emsdk-$(EmSdkVersion)"))</EmscriptenRoot>
+        <EmscriptenRoot Condition="'$(EMSDK)' != ''">$(EMSDK)</EmscriptenRoot> 
     </PropertyGroup>
 
+    <!--
+        MSBuild stuff to acquire the necessary SDKs (WASI SDK and Emscripten) automatically. It will take a few mins on the
+        first build on a given machine, but after that should no-op.
+    -->
+    <Target Name="PrepareWasmSdks" BeforeTargets="CheckWasmSdks" DependsOnTargets="ObtainWasiSdk; ObtainEmscripten">
+        <PropertyGroup>
+            <EmSdk>$(EmscriptenRoot)</EmSdk>
+            <Wasicompiler>$(EmscriptenRoot)\upstream\emscripten\emcc.bat</Wasicompiler>
+            <WASI_SDK_PATH>$(WasiSdkRoot)</WASI_SDK_PATH>
+        </PropertyGroup>
+    </Target>
+
+    <Target Name="ObtainEmscripten" Condition="'$(EMSDK)' == '' AND !(Exists($(EmscriptenRoot)))">
+        <!--
+            This is not ideal because if your solution has multiple projects that use WasmComponent.Sdk, then if you
+            build in parallel in CI where your machine doesn't already have wasi-sdk/emsdk, then it may try to download
+            and extract the SDKs multiple times in parallel to the same disk location, which may cause it to fail.
+            The only reason this doesn't happen in this repo is that it explicitly runs the PrepareWasmSdks task before
+            building other projects.
+
+            For a proper fix, consider implementing an MSBuild task in C# that obtains wasi-sdk/emsdk, and uses a mutex
+            so that only one flow executes at a time, with others blocking until it's done.
+        -->
+
+        <PropertyGroup>
+            <EmSdkDownloadTempDir>$([System.IO.Path]::Combine($([System.IO.Path]::GetTempPath()), $([System.IO.Path]::GetRandomFileName())))</EmSdkDownloadTempDir>
+        </PropertyGroup>
+
+        <MakeDir Directories="$(EmSdkDownloadTempDir)" />
+        <DownloadFile
+            SourceUrl="$(EmSdkUrl)"
+            DestinationFolder="$(EmSdkDownloadTempDir)">
+            <Output TaskParameter="DownloadedFile" ItemName="EmSdkDownloadTempFile" />
+        </DownloadFile>
+
+        <!-- Windows 10+ has tar built in, so this should work cross-platform -->
+        <Message Importance="high" Text="Extracting @(EmSdkDownloadTempFile) to $(EmscriptenRoot)..." />
+        <MakeDir Directories="$(EmscriptenRoot)" />
+        <Exec Command="tar -xf &quot;@(EmSdkDownloadTempFile)&quot; -C . --strip-components=1" WorkingDirectory="$(EmscriptenRoot)" />
+        <RemoveDir Directories="$(EmSdkDownloadTempDir)" />
+
+        <Exec Command="emsdk install $(EmSdkVersion)" WorkingDirectory="$(EmscriptenRoot)" />
+        <Exec Command="emsdk activate $(EmSdkVersion)" WorkingDirectory="$(EmscriptenRoot)" />
+    </Target>
+
+    <Target Name="ObtainWasiSdk" Condition="!(Exists($(WasiSdkRoot)))">
+        <PropertyGroup>
+            <WasiSdkDownloadTempDir>$([System.IO.Path]::Combine($([System.IO.Path]::GetTempPath()), $([System.IO.Path]::GetRandomFileName())))</WasiSdkDownloadTempDir>
+        </PropertyGroup>
+
+        <MakeDir Directories="$(WasiSdkDownloadTempDir)" />
+        <DownloadFile
+            SourceUrl="$(WasiSdkUrl)"
+            DestinationFolder="$(WasiSdkDownloadTempDir)">
+            <Output TaskParameter="DownloadedFile" ItemName="WasiSdkDownloadTempFile" />
+        </DownloadFile>
+
+        <!-- Windows 10+ has tar built in, so this should work cross-platform -->
+        <Message Importance="high" Text="Extracting @(WasiSdkDownloadTempFile) to $(WasiSdkRoot)..." />
+        <MakeDir Directories="$(WasiSdkRoot)" />
+        <Exec Command="tar -xf &quot;@(WasiSdkDownloadTempFile)&quot; -C . --strip-components=1" WorkingDirectory="$(WasiSdkRoot)" />
+        <RemoveDir Directories="$(WasiSdkDownloadTempDir)" />
+    </Target>
+
+    <!--
+        Following generats and compiles the wit code for the c# project
+    -->
     <Target Name="WitCompile_BeforeCsCompile" BeforeTargets="BeforeCompile"
 			Condition="'$(Language)' == 'C#' AND '@(Wit)' != ''"
-            DependsOnTargets="WitCompile_GetDependencies; WitCompile_InvokeTool">
+            DependsOnTargets="PrepareWasmSdks; WitCompile_GetDependencies; WitCompile_InvokeTool">
         <ItemGroup>
             <Compile Include="$(WitGeneratedFilesRoot)**\*.cs" />
             <NativeObjects Include="$(WitGeneratedFilesRoot)**\*.o" />
@@ -40,8 +120,8 @@
         <ItemGroup>
             <CabiReAllocFiles Include="$(WitGeneratedFilesRoot)**\*World_cabi_realloc.c" />
           </ItemGroup>
-          <Message Importance="high" Text="building cabi... @(CabiReAllocFiles->'&quot;%(FullPath)&quot;', ' ')" />
-        <Exec WorkingDirectory="$(WitGeneratedFilesRoot)" Command="emcc.bat @(CabiReAllocFiles->'&quot;%(FullPath)&quot;', ' ') -c"/>
+          <Message Importance="high" Text="building cabi_realloc files... @(CabiReAllocFiles->'&quot;%(FullPath)&quot;', ' ') with $(Wasicompiler)" />
+        <Exec WorkingDirectory="$(WitGeneratedFilesRoot)" Command="&quot;$(Wasicompiler)&quot; @(CabiReAllocFiles->'&quot;%(FullPath)&quot;', ' ') -c"/>
         
         <ItemGroup>
             <WitGeneratedCsFiles Include="$(WitGeneratedFilesRoot)**\*.cs" />

--- a/src/WitBindgen/build/WitBindgen.targets
+++ b/src/WitBindgen/build/WitBindgen.targets
@@ -1,4 +1,8 @@
 ﻿<Project>
+    <PropertyGroup>
+        <WitBindgenRuntime>native-aot</WitBindgenRuntime>
+    </PropertyGroup>
+
     <Target Name="WitCompile_BeforeCsCompile" BeforeTargets="BeforeCompile"
 			Condition="'$(Language)' == 'C#' AND '@(Wit)' != ''"
             DependsOnTargets="WitCompile_GetDependencies; WitCompile_InvokeTool">
@@ -29,8 +33,15 @@
         
         <RemoveDir Directories="$(WitGeneratedFilesRoot)" />
         <MakeDir Directories="$(WitGeneratedFilesRoot)" />
-        <Exec Command="$(WitBindgenExe) c-sharp %(Wit.Identity) %(Wit.WitWorldArg) --out-dir $(WitGeneratedFilesRoot)" />
+        <Exec Command="$(WitBindgenExe) c-sharp %(Wit.Identity) %(Wit.WitWorldArg) --runtime $(WitBindgenRuntime) --out-dir $(WitGeneratedFilesRoot)" />
         <WriteLinesToFile File="$(WitGeneratedFilesRoot)lastbuild.txt" Lines="" Overwrite="true" />
+
+        <!-- Need to compile cabi from c https://github.com/bytecodealliance/wit-bindgen/pull/791-->
+        <ItemGroup>
+            <CabiReAllocFiles Include="$(WitGeneratedFilesRoot)**\*World_cabi_realloc.c" />
+          </ItemGroup>
+          <Message Importance="high" Text="building cabi... @(CabiReAllocFiles->'&quot;%(FullPath)&quot;', ' ')" />
+        <Exec WorkingDirectory="$(WitGeneratedFilesRoot)" Command="emcc.bat @(CabiReAllocFiles->'&quot;%(FullPath)&quot;', ' ') -c"/>
         
         <ItemGroup>
             <WitGeneratedCsFiles Include="$(WitGeneratedFilesRoot)**\*.cs" />

--- a/test/E2ETest/PackageTest/PackageTest.csproj
+++ b/test/E2ETest/PackageTest/PackageTest.csproj
@@ -27,7 +27,6 @@
         </PackageReference>
 
         <!-- To ensure we don't build this until we've built the underlying packages -->
-        <ProjectReference Include="..\testapps\E2EConsumer\E2EConsumer.csproj" ReferenceOutputAssembly="false" />
         <ProjectReference Include="..\..\..\src\WasmComponent.Sdk\WasmComponent.Sdk.csproj" ReferenceOutputAssembly="false" />
     </ItemGroup>
 

--- a/test/E2ETest/PackageTest/PackageTest.csproj
+++ b/test/E2ETest/PackageTest/PackageTest.csproj
@@ -27,21 +27,25 @@
         </PackageReference>
 
         <!-- To ensure we don't build this until we've built the underlying packages -->
+        <ProjectReference Include="..\testapps\E2EConsumer\E2EConsumer.csproj" ReferenceOutputAssembly="false" />
         <ProjectReference Include="..\..\..\src\WasmComponent.Sdk\WasmComponent.Sdk.csproj" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
+    <!-- The next targets (+ nuget.config in folder above) ensures we have the latest nuget packages for the e2e test since there is no great way to force a project to use a particular nuget pacakage -->
     <Target Name="BuildTestProjects" DependsOnTargets="PackPackagesForE2ETest" BeforeTargets="Build">
-        <RemoveDir Directories="$(HomeDir)\.nuget\packages\witbindgen\$(PackageVersion)" />
-        <RemoveDir Directories="$(HomeDir)\.nuget\packages\wasmcomponent.sdk\$(PackageVersion)" />
+        <Message Importance="high" Text="Rebuilding e2e test projects..." />
+        <RemoveDir Directories="$(NugetPackageRoot)\witbindgen\$(PackageVersion)" />
+        <RemoveDir Directories="$(NugetPackageRoot)\wasmcomponent.sdk\$(PackageVersion)" />
         <RemoveDir Directories="..\testapps\E2EProducer\obj" />
         <RemoveDir Directories="..\testapps\E2EConsumer\obj" />
         <Exec Command="dotnet restore --no-cache" WorkingDirectory="..\testapps\E2EConsumer" />
-        <Exec Command="dotnet build" WorkingDirectory="..\testapps\E2EConsumer" />
+        <Exec Command="dotnet build --no-restore" WorkingDirectory="..\testapps\E2EConsumer" />
     </Target>
 
     <Target Name="PackPackagesForE2ETest">
+        <Message Importance="high" Text="Repackaging nuget packages for e2e tests to $(DevPackagesDir)" />
+        <RemoveDir Directories="$(DevPackagesDir)"/>
         <Exec Command="dotnet pack -c $(Configuration) WitBindgen.csproj -o $(DevPackagesDir)" WorkingDirectory="..\..\..\src\WitBindgen" />
         <Exec Command="dotnet pack -c $(Configuration) WasmComponent.Sdk.csproj -o $(DevPackagesDir)" WorkingDirectory="..\..\..\src\WasmComponent.Sdk" />
     </Target>
-
 </Project>

--- a/test/E2ETest/testapps/E2EConsumer/E2EConsumer.csproj
+++ b/test/E2ETest/testapps/E2EConsumer/E2EConsumer.csproj
@@ -33,11 +33,11 @@
     <!-- After build, create the composed component so it can be executed in the test -->
     <Target Name="ComposeWasmComponent" AfterTargets="ConvertToWasmComponent">
         <PropertyGroup>
-            <DependencyComponent>../E2EProducer/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/E2EProducer.component.wasm</DependencyComponent>
+            <DependencyComponent>../E2EProducer/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/e2eproducer-component.wasm</DependencyComponent>
         </PropertyGroup>
 
         <MakeDir Directories="dist" />
-        <Exec Command="$(WasmToolsExe) compose -o dist/composed.wasm bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/E2EConsumer.component.wasm -d $(DependencyComponent)" />
+        <Exec Command="$(WasmToolsExe) compose -o dist/composed.wasm bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/e2econsumer-component.wasm -d $(DependencyComponent)" />
     </Target>
 
 </Project>

--- a/test/E2ETest/testapps/E2EConsumer/Program.cs
+++ b/test/E2ETest/testapps/E2EConsumer/Program.cs
@@ -1,5 +1,5 @@
 ﻿using System.Runtime.InteropServices;
-using wit_consumer.Wit.imports.test.producerConsumer.Operations;
+using ConsumerWorld.wit.imports.test.producerConsumer;
 
 Console.WriteLine($"Hello, world on {RuntimeInformation.OSArchitecture}");
 

--- a/test/E2ETest/testapps/E2EProducer/E2EProducer.csproj
+++ b/test/E2ETest/testapps/E2EProducer/E2EProducer.csproj
@@ -6,7 +6,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+        <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>   
 
         <InvariantGlobalization>true</InvariantGlobalization>
         <RuntimeIdentifier>wasi-wasm</RuntimeIdentifier>

--- a/test/E2ETest/testapps/E2EProducer/OperationsImpl.cs
+++ b/test/E2ETest/testapps/E2EProducer/OperationsImpl.cs
@@ -1,6 +1,6 @@
-﻿namespace wit_producer.Wit.exports.test.producerConsumer.Operations;
+﻿namespace ProducerWorld.wit.exports.test.producerConsumer;
 
-public class OperationsImpl : Operations
+public class OperationsImpl : IOperations
 {
     public static int Add(int left, int right)
     {

--- a/test/WasmComponentSdkTest/WasmComponentSdkTest/SimpleProducerConsumerTest.cs
+++ b/test/WasmComponentSdkTest/WasmComponentSdkTest/SimpleProducerConsumerTest.cs
@@ -19,14 +19,14 @@ public class SimpleProducerConsumerTest
     [Fact]
     public void CanBuildComponentWithImport()
     {
-        var witInfo = GetWitInfo(FindModulePath($"../testapps/SimpleConsumer/bin/{Config}", "SimpleConsumer.component.wasm"));
+        var witInfo = GetWitInfo(FindModulePath($"../testapps/SimpleConsumer/bin/{Config}", "simpleconsumer-component.wasm"));
         Assert.Contains("import test:producer-consumer/operations", witInfo);
     }
 
     [Fact]
     public void CanBuildComponentWithExport()
     {
-        var witInfo = GetWitInfo(FindModulePath($"../testapps/SimpleProducer/bin/{Config}", "SimpleProducer.component.wasm"));
+        var witInfo = GetWitInfo(FindModulePath($"../testapps/SimpleProducer/bin/{Config}", "simpleproducer-component.wasm"));
         Assert.Contains("export test:producer-consumer/operations", witInfo);
     }
 

--- a/test/WasmComponentSdkTest/testapps/SimpleConsumer/Program.cs
+++ b/test/WasmComponentSdkTest/testapps/SimpleConsumer/Program.cs
@@ -1,5 +1,5 @@
 ﻿using System.Runtime.InteropServices;
-using wit_consumer.Wit.imports.test.producerConsumer.Operations;
+using ConsumerWorld.wit.imports.test.producerConsumer;
 
 Console.WriteLine($"Hello, world on {RuntimeInformation.OSArchitecture}");
 

--- a/test/WasmComponentSdkTest/testapps/SimpleConsumer/SimpleConsumer.csproj
+++ b/test/WasmComponentSdkTest/testapps/SimpleConsumer/SimpleConsumer.csproj
@@ -31,7 +31,7 @@
     <!-- After build, create the composed component so it can be executed in the test -->
     <Target Name="ComposeWasmComponent" AfterTargets="ConvertToWasmComponent">
         <PropertyGroup>
-            <DependencyComponent>../SimpleProducer/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/SimpleProducer.component.wasm</DependencyComponent>
+            <DependencyComponent>../SimpleProducer/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/simpleproducer-component.wasm</DependencyComponent>
         </PropertyGroup>
 
         <MakeDir Directories="dist" />

--- a/test/WasmComponentSdkTest/testapps/SimpleProducer/OperationsImpl.cs
+++ b/test/WasmComponentSdkTest/testapps/SimpleProducer/OperationsImpl.cs
@@ -1,6 +1,6 @@
-﻿namespace wit_producer.Wit.exports.test.producerConsumer.Operations;
+﻿namespace ProducerWorld.wit.exports.test.producerConsumer;
 
-public class OperationsImpl : Operations
+public class OperationsImpl : IOperations
 {
     public static int Add(int left, int right)
     {

--- a/test/WasmtimeCliFetcher/FetchWasmtime.targets
+++ b/test/WasmtimeCliFetcher/FetchWasmtime.targets
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <WasmtimeVersion>14.0.4</WasmtimeVersion>
+        <WasmtimeVersion>21.0.1</WasmtimeVersion>
 
         <WasmtimeTarget Condition="$([MSBuild]::IsOSPlatform('Windows'))">mingw</WasmtimeTarget>
         <WasmtimeTarget Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux</WasmtimeTarget>
@@ -10,15 +10,21 @@
 
         <WasmtimeExe>$(MSBuildThisFileDirectory)tools\wasmtime</WasmtimeExe>
         <WasmtimeExe Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(WasmtimeExe).exe</WasmtimeExe>
+        
+        <!-- This is a marker file that lets the build scripts identity if the files need to be modified when updating versions -->
+        <CurrentWasmtimeVersion>$(MSBuildThisFileDirectory)tools\version-$(WasmtimeVersion)</CurrentWasmtimeVersion>
 
         <WasmtimeUrlExtension>.tar.gz</WasmtimeUrlExtension>
         <WasmtimeUrlExtension Condition="$([MSBuild]::IsOSPlatform('Windows'))">.zip</WasmtimeUrlExtension>
         <WasmtimeUrl>https://github.com/bytecodealliance/wasmtime/releases/download/v$(WasmtimeVersion)/wasmtime-v$(WasmtimeVersion)-$(WasmtimeTarget)$(WasmtimeUrlExtension)</WasmtimeUrl>
     </PropertyGroup>
 
-    <Target Name="AcquireWasmtime" BeforeTargets="CoreBuild" Condition="!Exists('$(WasmtimeExe)')">
-        <DownloadFile SourceUrl="$(WasmtimeUrl)" DestinationFolder="$(MSBuildThisFileDirectory)tools" DestinationFileName="temp$(WasmtimeUrlExtension)" />
-        <Exec Command="tar -xf temp$(WasmtimeUrlExtension) --strip-components=1" WorkingDirectory="$(MSBuildThisFileDirectory)tools" />
+
+    <Target Name="AcquireWasmtime" Condition="!Exists('$(CurrentWasmtimeVersion)')" BeforeTargets="CoreBuild">
+        <RemoveDir Directories="$(MSBuildThisFileDirectory)tools" />
+        <DownloadFile SourceUrl="$(WasmtimeUrl)" DestinationFolder="$(MSBuildThisFileDirectory)tools" DestinationFileName="temp$(WasmtimeUrlExtension)" />	        
+        <WriteLinesToFile File="$(CurrentWasmtimeVersion)" Lines="$(WasmtimeVersion)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+        <Exec Command="tar -xf temp$(WasmtimeUrlExtension) --strip-components=1" WorkingDirectory="$(MSBuildThisFileDirectory)tools" />	  
         <Delete Files="$(MSBuildThisFileDirectory)tools\temp$(WasmtimeUrlExtension)" />
     </Target>
 </Project>

--- a/test/WitBindgenTest/WitBindgenTest/CodeGenerationTest.cs
+++ b/test/WitBindgenTest/WitBindgenTest/CodeGenerationTest.cs
@@ -1,5 +1,5 @@
-using wit_my_funcs;
-using wit_producer;
+using MyFuncsWorld;
+using ProducerWorld;
 using Xunit;
 
 namespace WitBindgenTest;
@@ -14,7 +14,7 @@ public class CodeGenerationTest
             LibraryUsingWit.Code.CallSimpleDoSomething());
 
         // Currently, it generates [DllImport("*", ...)] so validate that
-        Assert.StartsWith("Unable to load DLL '*'", ex.Message);
+        Assert.StartsWith("Unable to load DLL", ex.Message);
     }
 
     [Fact]

--- a/test/WitBindgenTest/testapps/LibraryUsingWit/Code.cs
+++ b/test/WitBindgenTest/testapps/LibraryUsingWit/Code.cs
@@ -4,6 +4,7 @@ public class Code
 {
     public static void CallSimpleDoSomething()
     {
-        wit_my_funcs.exports.MyFuncsWorld.DoSomething();
+        MyFuncsWorld.exports.MyFuncsWorld.DoSomething();
     }
+
 }

--- a/test/WitBindgenTest/testapps/LibraryUsingWit/MyFuncsWorldImpl.cs
+++ b/test/WitBindgenTest/testapps/LibraryUsingWit/MyFuncsWorldImpl.cs
@@ -1,6 +1,6 @@
-﻿namespace wit_my_funcs;
+﻿using MyFuncsWorld;
 
-public class MyFuncsWorldImpl : MyFuncsWorld
+public class MyFuncsWorldImpl : IMyFuncsWorld
 {
     public static int GetNumber()
     {

--- a/test/WitBindgenTest/testapps/LibraryUsingWit/SomeStuffImpl.cs
+++ b/test/WitBindgenTest/testapps/LibraryUsingWit/SomeStuffImpl.cs
@@ -1,10 +1,8 @@
 ﻿// I don't think this namespace should be so different to the one in MyFuncsWorldImpl,
 // but currently that's what the codegen requires
-using wit_producer.Wit.exports.test.multipleWorlds.SomeStuff;
+using ProducerWorld.wit.exports.test.multipleWorlds;
 
-namespace wit_producer;
-
-public class SomeStuffImpl : SomeStuff
+public class SomeStuffImpl : ISomeStuff
 {
     public static int GetNumber()
     {


### PR DESCRIPTION
This does a few things:

- switches the default build mode to use released versions of tools
- updates the submodules to point main projects
- Updates the versions of wit-bindgen, wasmtools and wasm-adapters
- Fixes all the samples and testing apps to use the generation changes in wit-bindgen
- updates some of the testing projects to update tools and nuget packages properly, prior to this the tools didn't update when values were changed locally 
- add some docs for contributing and debugging