### PR TITLE
Switch to using the wasi-sdk clang to build cabi_realloc files

### DIFF
--- a/src/WitBindgen/build/WitBindgen.targets
+++ b/src/WitBindgen/build/WitBindgen.targets
@@ -22,8 +22,10 @@
     -->
     <Target Name="PrepareWasmSdks" BeforeTargets="CheckWasmSdks" DependsOnTargets="ObtainWasiSdk; ObtainEmscripten">
         <PropertyGroup>
+            <ClangExeName>clang</ClangExeName>
+            <ClangExeName Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(ClangExeName).exe</ClangExeName>
             <EmSdk>$(EmscriptenRoot)</EmSdk>
-            <Wasicompiler>$(EmscriptenRoot)\upstream\emscripten\emcc.bat</Wasicompiler>
+            <Wasicompiler>$(WasiSdkRoot)\bin\$(ClangExeName)</Wasicompiler>
             <WASI_SDK_PATH>$(WasiSdkRoot)</WASI_SDK_PATH>
         </PropertyGroup>
     </Target>


### PR DESCRIPTION
This is another step towards #6 and #7.  This also fixes a bug that lets it run on multiple os's when compiling. 