### PR TITLE
Support wasi 0.2.0 directly

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- find latest versions at https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-experimental by name of package -->
-    <PackageVersion Include="Microsoft.DotNet.ILCompiler.LLVM" Version="9.0.0-preview.5.24304.1" />
-    <PackageVersion Include="runtime.win-x64.Microsoft.DotNet.ILCompiler.LLVM" Version="9.0.0-preview.5.24304.1" />
+    <PackageVersion Include="Microsoft.DotNet.ILCompiler.LLVM" Version="9.0.0-rc.1.24412.1" />
+    <PackageVersion Include="runtime.win-x64.Microsoft.DotNet.ILCompiler.LLVM" Version="9.0.0-rc.1.24412.1" />
 
     <!-- Tests -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />

--- a/README.md
+++ b/README.md
@@ -101,12 +101,6 @@ Another option, if you use Visual Studio, is to select the WIT file in *Solution
 
 You can simply type the world name `hostapp` into the properties pane.
 
-For now, you must also specify the functions you want to import in the `.csproj` file.  Add this to the `ItemGroup`:
-
-```xml
-    <WasmImport Include="example:calculator/operations!add" />
-```
-
 Now you can call the imported `Add` function by putting the following in `Program.cs`:
 
 ```cs

--- a/samples/calculator/CalculatorComposed/CalculatorComposed.csproj
+++ b/samples/calculator/CalculatorComposed/CalculatorComposed.csproj
@@ -17,8 +17,8 @@
 
     <Target Name="ComposeWasmComponent" AfterTargets="Build">
         <PropertyGroup>
-            <EntrypointComponent>../CalculatorHost/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/calculatorhost-component.wasm</EntrypointComponent>
-            <DependencyComponent>../Adder/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/adder-component.wasm</DependencyComponent>
+            <EntrypointComponent>../CalculatorHost/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/calculatorhost.wasm</EntrypointComponent>
+            <DependencyComponent>../Adder/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/adder.wasm</DependencyComponent>
         </PropertyGroup>
         
         <MakeDir Directories="dist" />

--- a/samples/calculator/CalculatorComposed/CalculatorComposed.csproj
+++ b/samples/calculator/CalculatorComposed/CalculatorComposed.csproj
@@ -15,7 +15,7 @@
       <ProjectReference Include="..\CalculatorHost\CalculatorHost.csproj" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
-    <Target Name="ComposeWasmComponent" AfterTargets="Build">
+    <Target Name="ComposeWasmComponent" AfterTargets="AfterBuild">
         <PropertyGroup>
             <EntrypointComponent>../CalculatorHost/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/calculatorhost.wasm</EntrypointComponent>
             <DependencyComponent>../Adder/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/adder.wasm</DependencyComponent>

--- a/samples/calculator/CalculatorHost/CalculatorHost.csproj
+++ b/samples/calculator/CalculatorHost/CalculatorHost.csproj
@@ -20,11 +20,6 @@
 
     <ItemGroup>
         <Wit Include="..\Adder\calculator.wit" World="hostapp" />
-        
-        <!-- Ideally this would be unnecessary, either because the MSBuild tooling adds it automatically, -->
-        <!-- or better still, the generated .cs code should include the full required annotations -->
-        <WasmImport Include="example:calculator/operations!add" />
-        <WasmImport Include="example:calculator/operations!to-upper" />
     </ItemGroup>
 
 </Project>

--- a/src/WasmComponent.Sdk/WasmComponent.Sdk.csproj
+++ b/src/WasmComponent.Sdk/WasmComponent.Sdk.csproj
@@ -44,7 +44,7 @@
         <None Include="ImportInDev.proj" />
     </ItemGroup>
 
-    <Target Name="BuildOrDownloadNativeTooling" BeforeTargets="Build" DependsOnTargets="BuildNativeTooling; DownloadNativeTooling; DownloadWasiPreview1Adapters">
+    <Target Name="BuildOrDownloadNativeTooling" BeforeTargets="Build" DependsOnTargets="BuildNativeTooling; DownloadNativeTooling;">
     </Target>
 
     <Target Name="BuildNativeTooling" Condition="'$(BuildWasmToolsLocally)' == 'true'">
@@ -79,12 +79,6 @@
         <MakeDir Directories="tools\%(PrebuiltWasmToolsTarget.Rid)" />
         <Exec Command="tar -xf &quot;temp/%(PrebuiltWasmToolsTarget.Rid)%(PrebuiltWasmToolsTarget.Ext)&quot; -C %(PrebuiltWasmToolsTarget.Rid) --strip-components=1" WorkingDirectory="tools" />
         <RemoveDir Directories="tools\temp" />
-    </Target>
-
-    <Target Name="DownloadWasiPreview1Adapters" Inputs="$(MSBuildThisFileDirectory)tools\wasi-wasm\version" Outputs="$(MSBuildThisFileDirectory)tools\wasi-wasm\version" >
-        <DownloadFile SourceUrl="https://github.com/bytecodealliance/wasmtime/releases/download/v$(WasmtimeVersionForWasiSnapshotPreview1Adapters)/wasi_snapshot_preview1.command.wasm" DestinationFolder="tools\wasi-wasm" />
-        <DownloadFile SourceUrl="https://github.com/bytecodealliance/wasmtime/releases/download/v$(WasmtimeVersionForWasiSnapshotPreview1Adapters)/wasi_snapshot_preview1.reactor.wasm" DestinationFolder="tools\wasi-wasm" />
-        <WriteLinesToFile File="$(MSBuildThisFileDirectory)tools\wasi-wasm\version" Lines="$(WasmtimeVersionForWasiSnapshotPreview1Adapters)" Overwrite="true"  WriteOnlyWhenDifferent="true" />
     </Target>
 
     <Target Name="PackTaskDependencies" BeforeTargets="GenerateNuspec">

--- a/src/WasmComponent.Sdk/build/ByteCodeAlliance.Componentize.DotNet.Wasm.SDK.targets
+++ b/src/WasmComponent.Sdk/build/ByteCodeAlliance.Componentize.DotNet.Wasm.SDK.targets
@@ -1,23 +1,6 @@
 <Project>
-    <Target Name="EmitWasmOnBuild" AfterTargets="CopyFilesToOutputDirectory" DependsOnTargets="LinkNativeLlvm; ConvertToWasmComponent"
+    <Target Name="EmitWasmOnBuild" AfterTargets="CopyFilesToOutputDirectory" DependsOnTargets="LinkNativeLlvm;"
             Condition="'$(RuntimeIdentifier)' == 'wasi-wasm'">
-        <Message Importance="high" Text="$(ProjectName) -> $([System.IO.Path]::GetFullPath('$(NativeComponentBinary)'))" />
-    </Target>
-
-    <Target Name="ConvertToWasmComponent" DependsOnTargets="GetConvertToWasmComponentDependencies" Inputs="$(WasiPreview1AdapterPath);$(NativeBinary)" Outputs="$(NativeComponentBinary)" >
-        <Exec Command="$(WasmToolsExe) component new $(NativeBinary) -o $(NativeComponentBinary) --adapt $(WasiPreview1AdapterPath)" />
-    </Target>
-
-    <Target Name="GetConvertToWasmComponentDependencies">
-        <PropertyGroup>
-            <WasiPreview1AdapterType>reactor</WasiPreview1AdapterType>
-            <WasiPreview1AdapterType Condition="'$(OutputType.ToLower())' == 'exe'">command</WasiPreview1AdapterType>
-            <WasiPreview1AdapterPath>$(MSBuildThisFileDirectory)../tools/wasi-wasm/wasi_snapshot_preview1.$(WasiPreview1AdapterType).wasm</WasiPreview1AdapterPath>
-            <!-- 
-                wasm compose requires kabab case (todo: revisit when move to wac https://github.com/bytecodealliance/componentize-dotnet/issues/5) 
-                https://github.com/bytecodealliance/wasm-tools/issues/1440
-            -->
-            <NativeComponentBinary>$(NativeOutputPath)$(TargetName.ToLower())-component.wasm</NativeComponentBinary>
-        </PropertyGroup>
+        <Message Importance="high" Text="Emit on build $(ProjectName) " />
     </Target>
 </Project>

--- a/src/WitBindgen/WitBindgen.csproj
+++ b/src/WitBindgen/WitBindgen.csproj
@@ -19,7 +19,7 @@
         <!-- Things you might want to edit -->
         <!-- Set BuildWitBindgenLocally to true if you want to build modules/wit-bindgen locally and use its output -->
         <BuildWitBindgenLocally>false</BuildWitBindgenLocally>
-        <PrebuiltWitBindgenVersion>0.29.0</PrebuiltWitBindgenVersion>
+        <PrebuiltWitBindgenVersion>0.30.0</PrebuiltWitBindgenVersion>
         <PrebuiltWitBindgenBaseUrl>https://github.com/bytecodealliance/wit-bindgen/releases/download/v$(PrebuiltWitBindgenVersion)/wit-bindgen-$(PrebuiltWitBindgenVersion)</PrebuiltWitBindgenBaseUrl>
         <WitBindgenModuleRoot>$(MSBuildThisFileDirectory)..\..\modules\wit-bindgen\</WitBindgenModuleRoot>
 

--- a/src/WitBindgen/build/ByteCodeAlliance.Componentize.DotNet.WitBindgen.props
+++ b/src/WitBindgen/build/ByteCodeAlliance.Componentize.DotNet.WitBindgen.props
@@ -26,7 +26,7 @@
             <Context>File;BrowseObject</Context>
         </PropertyPageSchema>
 
-        <Wit Include="*.wit" />
+        <Wit Include="*.wit;wit/*.wit" />
 
         <!-- Treats this itemgroup as a compilation input (e.g., changes affect VS fast up-to-date check, and generator is shown in properties pane) -->
         <AvailableItemName Include="Wit" />

--- a/src/WitBindgen/build/ByteCodeAlliance.Componentize.DotNet.WitBindgen.props
+++ b/src/WitBindgen/build/ByteCodeAlliance.Componentize.DotNet.WitBindgen.props
@@ -26,7 +26,7 @@
             <Context>File;BrowseObject</Context>
         </PropertyPageSchema>
 
-        <Wit Include="**\*.wit" />
+        <Wit Include="*.wit" />
 
         <!-- Treats this itemgroup as a compilation input (e.g., changes affect VS fast up-to-date check, and generator is shown in properties pane) -->
         <AvailableItemName Include="Wit" />

--- a/src/WitBindgen/build/ByteCodeAlliance.Componentize.DotNet.WitBindgen.targets
+++ b/src/WitBindgen/build/ByteCodeAlliance.Componentize.DotNet.WitBindgen.targets
@@ -1,12 +1,12 @@
-<Project>
+﻿<Project>
     <PropertyGroup>
         <WitBindgenRuntime>native-aot</WitBindgenRuntime>
 
         <!-- Keep this block all in sync manually, since URLs can be arbitrary -->
-        <WasiSdkVersion>22.0</WasiSdkVersion>
-        <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('Windows'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$(WasiSdkVersion.Split(".")[0])/wasi-sdk-$(WasiSdkVersion).m-mingw64.tar.gz</WasiSdkUrl>
-        <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('Linux'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$(WasiSdkVersion.Split(".")[0])/wasi-sdk-$(WasiSdkVersion)-linux.tar.gz</WasiSdkUrl>
-        <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('OSX'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$(WasiSdkVersion.Split(".")[0])/wasi-sdk-$(WasiSdkVersion)-macos.tar.gz</WasiSdkUrl>
+        <WasiSdkVersion>24.0</WasiSdkVersion>
+        <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('Windows'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$(WasiSdkVersion.Split(".")[0])/wasi-sdk-$(WasiSdkVersion)-x86_64-windows.tar.gz</WasiSdkUrl>
+        <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('Linux'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$(WasiSdkVersion.Split(".")[0])/wasi-sdk-$(WasiSdkVersion)-x86_64-linux.tar.gz</WasiSdkUrl>
+        <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('OSX'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$(WasiSdkVersion.Split(".")[0])/wasi-sdk-$(WasiSdkVersion)-x86_64-macos.tar.gz</WasiSdkUrl>
         <WasiSdkRoot>$([System.IO.Path]::Combine("$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))", ".wasi-sdk", "wasi-sdk-$(WasiSdkVersion)"))</WasiSdkRoot>
 
     </PropertyGroup>
@@ -17,9 +17,6 @@
     -->
     <Target Name="PrepareWasmSdks" BeforeTargets="CheckWasmSdks" DependsOnTargets="ObtainWasiSdk">
         <PropertyGroup>
-            <ClangExeName>clang</ClangExeName>
-            <ClangExeName Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(ClangExeName).exe</ClangExeName>
-            <Wasicompiler>$(WasiSdkRoot)\bin\$(ClangExeName)</Wasicompiler>
             <WASI_SDK_PATH>$(WasiSdkRoot)</WASI_SDK_PATH>
         </PropertyGroup>
     </Target>
@@ -46,16 +43,15 @@
     <!--
         Following generats and compiles the wit code for the c# project
     -->
-    <Target Name="WitCompile_BeforeCsCompile" BeforeTargets="BeforeCompile"
+    <Target Name="WitCompile_BeforeCsCompile" BeforeTargets="LinkNativeLlvm; BeforeCompile; "
 			Condition="'$(Language)' == 'C#' AND '@(Wit)' != ''"
             DependsOnTargets="PrepareWasmSdks; WitCompile_GetDependencies; WitCompile_InvokeTool">
         <ItemGroup>
             <Compile Include="$(WitGeneratedFilesRoot)**\*.cs" />
-            <NativeObjects Include="$(WitGeneratedFilesRoot)**\*.o" />
         </ItemGroup>
     </Target>
 
-    <Target Name="PullWitOciFiles" Inputs="@(Wit)" Outputs="@(Wit)" BeforeTargets="WitCompile_GetDependencies">
+    <Target Name="PullWitOciFiles" Inputs="@(Wit)" Outputs="@(Wit)" BeforeTargets="WitCompile_InvokeTool">
         <PropertyGroup>
             <WitOciFile>@(Wit)</WitOciFile>
         </PropertyGroup>
@@ -64,16 +60,21 @@
         <Exec Condition="'%(Wit.Registry)' != ''" Command="$(WkgExe) oci pull %(Wit.Registry) --output $(WitOciFile)" /> 
     </Target>
 
-    <Target Name="WitCompile_GetDependencies">
-        <PropertyGroup>
-            <WitGeneratedFilesRoot Condition="'$(WitGeneratedFilesRoot)' == ''">$(IntermediateOutputPath)wit_bindgen\</WitGeneratedFilesRoot>
-        </PropertyGroup>
+    <Target Name="WitCompile_GetDependencies" DependsOnTargets="WitCompile_InvokeTool">
+       
         <ItemGroup>
             <WitGeneratedCsFiles Include="$(WitGeneratedFilesRoot)**\*.cs" />
+            <WitComponentImports Include="$(WitGeneratedFilesRoot)**\*.wit"/>
+        </ItemGroup>
+        <ItemGroup>
+            <CustomLinkerArg Include="@(WitComponentImports->Replace('\', '/')->'-Wl,--component-type,&quot;%(Identity)&quot;')" />
         </ItemGroup>
     </Target>
 
     <Target Name="WitCompile_InvokeTool" Inputs="@(Wit);$(MSBuildProjectFile)" Outputs="@(WitGeneratedCsFiles);$(WitGeneratedFilesRoot)lastbuild.txt">
+        <PropertyGroup>
+            <WitGeneratedFilesRoot Condition="'$(WitGeneratedFilesRoot)' == ''">$(IntermediateOutputPath)wit_bindgen\</WitGeneratedFilesRoot>
+        </PropertyGroup>
         <ItemGroup>
             <WitGeneratedCsFiles Remove="@(WitGeneratedCsFiles)" />
             <Wit Update="@(Wit)">
@@ -87,13 +88,6 @@
         <MakeDir Directories="$(WitGeneratedFilesRoot)" />
         <Exec Command="$(WitBindgenExe) c-sharp %(Wit.Identity) %(Wit.WitWorldArg) --runtime $(WitBindgenRuntime) --out-dir $(WitGeneratedFilesRoot)" />
         <WriteLinesToFile File="$(WitGeneratedFilesRoot)lastbuild.txt" Lines="" Overwrite="true" />
-
-        <!-- Need to compile cabi from c https://github.com/bytecodealliance/wit-bindgen/pull/791-->
-        <ItemGroup>
-            <CabiReAllocFiles Include="$(WitGeneratedFilesRoot)**\*World_cabi_realloc.c" />
-        </ItemGroup>
-        <Message Importance="high" Text="building cabi_realloc files... @(CabiReAllocFiles->'&quot;%(FullPath)&quot;', ' ') with $(Wasicompiler)" />
-        <Exec WorkingDirectory="$(WitGeneratedFilesRoot)" Command="&quot;$(Wasicompiler)&quot; @(CabiReAllocFiles->'&quot;%(FullPath)&quot;', ' ') -c"/>
         
         <ItemGroup>
             <WitGeneratedCsFiles Include="$(WitGeneratedFilesRoot)**\*.cs" />

--- a/test/E2ETest/testapps/E2EConsumer/E2EConsumer.csproj
+++ b/test/E2ETest/testapps/E2EConsumer/E2EConsumer.csproj
@@ -24,20 +24,16 @@
 
     <ItemGroup>
         <Wit Include="..\E2EProducer\producer-consumer.wit" World="consumer" />
-
-        <!-- Ideally this would be unnecessary, either because the MSBuild tooling adds it automatically, -->
-        <!-- or better still, the generated .cs code should include the full required annotations -->
-        <WasmImport Include="test:producer-consumer/operations!add" />
     </ItemGroup>
     
     <!-- After build, create the composed component so it can be executed in the test -->
-    <Target Name="ComposeWasmComponent" AfterTargets="ConvertToWasmComponent">
+    <Target Name="ComposeWasmComponent" DependsOnTargets="CopyFilesToOutputDirectory">
         <PropertyGroup>
-            <DependencyComponent>../E2EProducer/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/e2eproducer-component.wasm</DependencyComponent>
+            <DependencyComponent>../E2EProducer/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/e2eproducer.wasm</DependencyComponent>
         </PropertyGroup>
 
         <MakeDir Directories="dist" />
-        <Exec Command="$(WasmToolsExe) compose -o dist/composed.wasm bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/e2econsumer-component.wasm -d $(DependencyComponent)" />
+        <Exec Command="$(WasmToolsExe) compose -o dist/composed.wasm $(NativeOutputPath)$(TargetName.ToLower()).wasm -d $(DependencyComponent)" />
     </Target>
 
 </Project>

--- a/test/E2ETest/testapps/E2EConsumer/E2EConsumer.csproj
+++ b/test/E2ETest/testapps/E2EConsumer/E2EConsumer.csproj
@@ -27,7 +27,7 @@
     </ItemGroup>
     
     <!-- After build, create the composed component so it can be executed in the test -->
-    <Target Name="ComposeWasmComponent" DependsOnTargets="CopyFilesToOutputDirectory">
+    <Target Name="ComposeWasmComponent" AfterTargets="AfterBuild">
         <PropertyGroup>
             <DependencyComponent>../E2EProducer/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/e2eproducer.wasm</DependencyComponent>
         </PropertyGroup>

--- a/test/WasmComponentSdkTest/WasmComponentSdkTest/SimpleProducerConsumerTest.cs
+++ b/test/WasmComponentSdkTest/WasmComponentSdkTest/SimpleProducerConsumerTest.cs
@@ -19,21 +19,21 @@ public class SimpleProducerConsumerTest
     [Fact]
     public void CanBuildComponentWithImport()
     {
-        var witInfo = GetWitInfo(FindModulePath($"../testapps/SimpleConsumer/bin/{Config}", "simpleconsumer-component.wasm"));
+        var witInfo = GetWitInfo(FindModulePath($"../testapps/SimpleConsumer/bin/{Config}", "simpleconsumer.wasm"));
         Assert.Contains("import test:producer-consumer/operations", witInfo);
     }
 
     [Fact]
     public void CanBuildComponentWithExport()
     {
-        var witInfo = GetWitInfo(FindModulePath($"../testapps/SimpleProducer/bin/{Config}", "simpleproducer-component.wasm"));
+        var witInfo = GetWitInfo(FindModulePath($"../testapps/SimpleProducer/bin/{Config}", "simpleproducer.wasm"));
         Assert.Contains("export test:producer-consumer/operations", witInfo);
     }
 
     [Fact]
     public void CanBuildComponentWithWitPackage()
     {
-        var witInfo = GetWitInfo(FindModulePath($"../testapps/AppWithWitFolder/bin/{Config}", "appwithwitfolder-component.wasm"));
+        var witInfo = GetWitInfo(FindModulePath($"../testapps/AppWithWitFolder/bin/{Config}", "appwithwitfolder.wasm"));
         Assert.Contains("import test:pkg/folder", witInfo);
     }
 
@@ -49,7 +49,7 @@ public class SimpleProducerConsumerTest
     [Fact]
     public void CanBuildAppFromOci()
     {
-        var composed = FindModulePath("../testapps/OciWit", "ociwit-component.wasm");
+        var composed = FindModulePath("../testapps/OciWit", "ociwit.wasm");
         var stdout = ExecuteCommandComponent(composed);
         Assert.StartsWith("Oci is awesome!", stdout);
     }

--- a/test/WasmComponentSdkTest/testapps/SimpleConsumer/SimpleConsumer.csproj
+++ b/test/WasmComponentSdkTest/testapps/SimpleConsumer/SimpleConsumer.csproj
@@ -22,20 +22,16 @@
 
     <ItemGroup>
         <Wit Include="..\SimpleProducer\producer-consumer.wit" World="consumer" />
-
-        <!-- Ideally this would be unnecessary, either because the MSBuild tooling adds it automatically, -->
-        <!-- or better still, the generated .cs code should include the full required annotations -->
-        <WasmImport Include="test:producer-consumer/operations!add" />
     </ItemGroup>
     
     <!-- After build, create the composed component so it can be executed in the test -->
-    <Target Name="ComposeWasmComponent" AfterTargets="ConvertToWasmComponent">
+    <Target Name="ComposeWasmComponent" AfterTargets="CopyFilesToOutputDirectory">
         <PropertyGroup>
-            <DependencyComponent>../SimpleProducer/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/simpleproducer-component.wasm</DependencyComponent>
+            <DependencyComponent>../SimpleProducer/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/simpleproducer.wasm</DependencyComponent>
         </PropertyGroup>
 
         <MakeDir Directories="dist" />
-        <Exec Command="$(WasmToolsExe) compose -o dist/composed.wasm $(NativeComponentBinary) -d $(DependencyComponent)" />
+        <Exec Command="$(WasmToolsExe) compose -o dist/composed.wasm $(NativeOutputPath)$(TargetName.ToLower()).wasm -d $(DependencyComponent)" />
     </Target>
 
 </Project>

--- a/test/WasmComponentSdkTest/testapps/SimpleConsumer/SimpleConsumer.csproj
+++ b/test/WasmComponentSdkTest/testapps/SimpleConsumer/SimpleConsumer.csproj
@@ -25,7 +25,7 @@
     </ItemGroup>
     
     <!-- After build, create the composed component so it can be executed in the test -->
-    <Target Name="ComposeWasmComponent" AfterTargets="CopyFilesToOutputDirectory">
+    <Target Name="ComposeWasmComponent" AfterTargets="AfterBuild">
         <PropertyGroup>
             <DependencyComponent>../SimpleProducer/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/simpleproducer.wasm</DependencyComponent>
         </PropertyGroup>


### PR DESCRIPTION
fixes #26

Updates to latest wit-bindgen which depends on the latest changes to .net which produce a 0.2.0 wasi component directly