### PR TITLE
The name of the artifact to download changed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,11 +34,13 @@ jobs:
       run: dotnet test --no-build --verbosity normal
     - name: Pack
       run: dotnet pack -c Release /p:BuildNumber=${{ github.run_number }}
+    # must use windows to generate package https://github.com/bytecodealliance/componentize-dotnet/issues/41
+    # only need one package published https://github.com/actions/upload-artifact?tab=readme-ov-file#not-uploading-to-the-same-artifact
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: nuget-packages-${{ matrix.os }}
+        name: nuget-packages
         path: artifacts/*.nupkg
         if-no-files-found: error
-      if: ${{ matrix.dotnet  == '8.x' }} # only need one package published https://github.com/actions/upload-artifact?tab=readme-ov-file#not-uploading-to-the-same-artifact
+      if: ${{ matrix.dotnet  == '8.x' && matrix.os == 'windows-latest' }} 
 


### PR DESCRIPTION
https://github.com/bytecodealliance/componentize-dotnet/actions/runs/10746685707

```
[Release](https://github.com/bytecodealliance/componentize-dotnet/actions/runs/10746685707/job/29808021637#step:4:11)
Unable to download artifact(s): Artifact not found for name: nuget-packages
        Please ensure that your artifact is not expired and the artifact was uploaded using a compatible version of toolkit/upload-artifact.
```