### PR TITLE
Add package ref at compile time not SDK build time

### DIFF
--- a/src/WasmComponent.Sdk/ImportInDev.proj
+++ b/src/WasmComponent.Sdk/ImportInDev.proj
@@ -6,7 +6,5 @@
     <Import Project="../WitBindgen/ImportInDev.proj" />
 
     <ItemGroup>
-		<PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM" />
-		<PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM" />
 	</ItemGroup>
 </Project>

--- a/src/WasmComponent.Sdk/WasmComponent.Sdk.csproj
+++ b/src/WasmComponent.Sdk/WasmComponent.Sdk.csproj
@@ -31,8 +31,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM" PrivateAssets="None" />
-        <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM" PrivateAssets="None" />
         <ProjectReference Include="..\WitBindgen\WitBindgen.csproj" PrivateAssets="None" />
     </ItemGroup>
 

--- a/src/WasmComponent.Sdk/build/BytecodeAlliance.Componentize.DotNet.Wasm.SDK.props
+++ b/src/WasmComponent.Sdk/build/BytecodeAlliance.Componentize.DotNet.Wasm.SDK.props
@@ -11,4 +11,9 @@
 		<WasmToolsExe>$(MSBuildThisFileDirectory)..\tools\$(WasmToolsTarget)\wasm-tools</WasmToolsExe>
 		<WasmToolsExe Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(WasmToolsExe).exe</WasmToolsExe>
 	</PropertyGroup>
+
+	<ItemGroup>
+        <PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM" PrivateAssets="None" />
+        <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM" PrivateAssets="None" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes issue where package would not work on Linux with out first running

```
dotnet add package runtime.linux-x64.Microsoft.DotNet.ILCompiler.LLVM --prerelease
```

https://bytecodealliance.zulipchat.com/#narrow/channel/407028-C.23.2F.2Enet-collaboration/topic/componentize-dotnet.20on.20linux