### PR TITLE
Update readme to support Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build on ${{ matrix.os }} with Dotnet ${{ matrix.dotnet }}
     strategy:
       matrix:
-        dotnet: [ '8.x', '9.0.100-rc.1.24452.12']
+        dotnet: [ '9.x']
         os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v4
@@ -42,5 +42,5 @@ jobs:
         name: nuget-packages
         path: artifacts/*.nupkg
         if-no-files-found: error
-      if: ${{ matrix.dotnet  == '8.x' && matrix.os == 'windows-latest' }} 
+      if: ${{ matrix.dotnet  == '9.x' && matrix.os == 'windows-latest' }} 
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,12 +4,12 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- find latest versions at https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-experimental by name of package -->
-    <PackageVersion Include="Microsoft.DotNet.ILCompiler.LLVM" Version="10.0.0-alpha.1.24525.6" />
-    <PackageVersion Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM" Version="10.0.0-alpha.1.24525.6" />
+    <PackageVersion Include="Microsoft.DotNet.ILCompiler.LLVM" Version="10.0.0-alpha.1.24573.1" />
+    <PackageVersion Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM" Version="10.0.0-alpha.1.24573.1" />
 
     <!-- Tests -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ With this package, you can add one NuGet reference. The build output is fully AO
 
 ### 1. Set up SDKs
 
-If you don't already have it, install [.NET 8+ SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
+If you don't already have it, install [.NET 9+ SDK](https://dotnet.microsoft.com/en-us/download/dotnet/9.0)
 
 ### 2. Create a project and add BytecodeAlliance.Componentize.DotNet.Wasm.SDK package
 
@@ -43,21 +43,21 @@ Create a `nuget.config` file and add the `dotnet-experimental` package source fo
 
 Add the `componentize-dotnet` package:
 
-* `dotnet add package BytecodeAlliance.Componentize.DotNet.Wasm.SDK --prerelease`
+`dotnet add package BytecodeAlliance.Componentize.DotNet.Wasm.SDK --prerelease`
 
-### 3. Configure the compilation output
+Add the platform specific LLVM package:
 
-Edit the `.csproj` file, adding the following inside the `<PropertyGroup>`:
+```
+## On Linux
+dotnet add package runtime.linux-x64.microsoft.dotnet.ilcompiler.llvm --version 10.0.0-alpha.1.24573.1 --prerelease
 
-```xml
-    <RuntimeIdentifier>wasi-wasm</RuntimeIdentifier>
-    <UseAppHost>false</UseAppHost>
-    <PublishTrimmed>true</PublishTrimmed>
-    <InvariantGlobalization>true</InvariantGlobalization>
-    <SelfContained>true</SelfContained>
+## or
+
+## On Windows
+dotnet add package runtime.windows-x64.microsoft.dotnet.ilcompiler.llvm --version 10.0.0-alpha.1.24573.1 --prerelease
 ```
 
-Now you can `dotnet build` to produce a `.wasm` file using NativeAOT compilation.
+Now you can `dotnet publish` to produce a `.wasm` file using NativeAOT compilation.
 
 ### 4. Run the WebAssembly binary
 

--- a/samples/calculator/Adder/Adder.csproj
+++ b/samples/calculator/Adder/Adder.csproj
@@ -5,11 +5,10 @@
 
     <PropertyGroup>
         <OutputType>Library</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
-        <InvariantGlobalization>true</InvariantGlobalization>
         <RuntimeIdentifier>wasi-wasm</RuntimeIdentifier>
 
         <!-- Need kebab case -->
@@ -18,6 +17,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\src\WasmComponent.Sdk\WasmComponent.Sdk.csproj" />
+        <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/calculator/CalculatorComposed/CalculatorComposed.csproj
+++ b/samples/calculator/CalculatorComposed/CalculatorComposed.csproj
@@ -7,12 +7,13 @@
     <!-- and express a dependency on the two implementation components. -->
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Adder\Adder.csproj" ReferenceOutputAssembly="false" />
       <ProjectReference Include="..\CalculatorHost\CalculatorHost.csproj" ReferenceOutputAssembly="false" />
+      <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM"/>
     </ItemGroup>
 
     <Target Name="ComposeWasmComponent" AfterTargets="AfterBuild">

--- a/samples/calculator/CalculatorHost/CalculatorHost.csproj
+++ b/samples/calculator/CalculatorHost/CalculatorHost.csproj
@@ -5,17 +5,16 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
-        <InvariantGlobalization>true</InvariantGlobalization>
-        <RuntimeIdentifier>wasi-wasm</RuntimeIdentifier>
         <IlcExportUnmanagedEntrypoints>true</IlcExportUnmanagedEntrypoints>
     </PropertyGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\src\WasmComponent.Sdk\WasmComponent.Sdk.csproj" />
+        <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/WasmComponent.Sdk/WasmComponent.Sdk.csproj
+++ b/src/WasmComponent.Sdk/WasmComponent.Sdk.csproj
@@ -11,7 +11,7 @@
         <PackageTags>webassembly, .net, wasm</PackageTags>
         <PackageReleaseNotes>https://github.com/bytecodealliance/componentize-dotnet/releases/tag/$(PackageVersion)</PackageReleaseNotes>
 
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>true</IsPackable>

--- a/src/WasmComponent.Sdk/build/BytecodeAlliance.Componentize.DotNet.Wasm.SDK.props
+++ b/src/WasmComponent.Sdk/build/BytecodeAlliance.Componentize.DotNet.Wasm.SDK.props
@@ -1,8 +1,13 @@
 <Project>
 	<PropertyGroup>
-		<PublishTrimmed>true</PublishTrimmed>
-		<UseAppHost>false</UseAppHost>
 		<MSBuildEnableWorkloadResolver>false</MSBuildEnableWorkloadResolver>
+
+		<!-- Set these by default -->
+		<RuntimeIdentifier>wasi-wasm</RuntimeIdentifier>
+		<UseAppHost>false</UseAppHost>
+		<PublishTrimmed>true</PublishTrimmed>
+		<InvariantGlobalization>true</InvariantGlobalization>
+		<SelfContained>true</SelfContained>
 
 		<WasmToolsTarget Condition="$([MSBuild]::IsOSPlatform('Windows'))">win</WasmToolsTarget>
 		<WasmToolsTarget Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux</WasmToolsTarget>
@@ -14,6 +19,5 @@
 
 	<ItemGroup>
         <PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM" PrivateAssets="None" />
-        <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM" PrivateAssets="None" />
     </ItemGroup>
 </Project>

--- a/src/WitBindgen/WitBindgen.csproj
+++ b/src/WitBindgen/WitBindgen.csproj
@@ -11,7 +11,7 @@
         <PackageTags>webassembly, .net, wasm</PackageTags>
         <PackageReleaseNotes>https://github.com/bytecodealliance/componentize-dotnet/releases/tag/$(PackageVersion)</PackageReleaseNotes>
 
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>true</IsPackable>

--- a/test/E2ETest/PackageTest/PackageTest.csproj
+++ b/test/E2ETest/PackageTest/PackageTest.csproj
@@ -2,7 +2,7 @@
     <Import Project="..\..\WasmtimeCliFetcher\FetchWasmtime.targets" />
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -28,6 +28,7 @@
 
         <!-- To ensure we don't build this until we've built the underlying packages -->
         <ProjectReference Include="..\..\..\src\WasmComponent.Sdk\WasmComponent.Sdk.csproj" ReferenceOutputAssembly="false" />
+        <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM"/>
     </ItemGroup>
 
     <!-- The next targets (+ nuget.config in folder above) ensures we have the latest nuget packages for the e2e test since there is no great way to force a project to use a particular nuget pacakage -->

--- a/test/E2ETest/testapps/E2EConsumer/E2EConsumer.csproj
+++ b/test/E2ETest/testapps/E2EConsumer/E2EConsumer.csproj
@@ -4,7 +4,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
@@ -18,6 +18,7 @@
 
     <ItemGroup>
         <PackageReference Include="BytecodeAlliance.Componentize.DotNet.Wasm.SDK" Version="$(PackageVersion)" />
+        <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM" Version="10.0.0-alpha.1.24573.1"/>
 
         <!-- Just to ensure build order -->
         <ProjectReference Include="..\E2EProducer\E2EProducer.csproj" ReferenceOutputAssembly="false" />

--- a/test/E2ETest/testapps/E2EProducer/E2EProducer.csproj
+++ b/test/E2ETest/testapps/E2EProducer/E2EProducer.csproj
@@ -3,7 +3,7 @@
     <!-- This project can't be included in the solution because its package reference can't be satisfied except when running under test -->
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>   
@@ -16,6 +16,7 @@
 
     <ItemGroup>
         <PackageReference Include="BytecodeAlliance.Componentize.DotNet.Wasm.SDK" Version="$(PackageVersion)" />
+        <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM" Version="10.0.0-alpha.1.24573.1"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/test/E2ETest/testapps/nuget.config
+++ b/test/E2ETest/testapps/nuget.config
@@ -2,11 +2,15 @@
 <configuration>
   <packageSources>
     <add key="dev" value="../PackageTest/packages" />
+    <add key="dotnet-experimental" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="dev">
       <package pattern="BytecodeAlliance.Componentize.DotNet.WitBindgen" />
       <package pattern="BytecodeAlliance.Componentize.DotNet.Wasm.SDK" />
+    </packageSource>
+    <packageSource key="dotnet-experimental">
+      <package pattern="runtime.*" />
     </packageSource>
   </packageSourceMapping>
 </configuration>

--- a/test/WasmComponentSdkTest/WasmComponentSdkTest/WasmComponentSdkTest.csproj
+++ b/test/WasmComponentSdkTest/WasmComponentSdkTest/WasmComponentSdkTest.csproj
@@ -3,10 +3,13 @@
     <Import Project="..\..\..\src\WasmComponent.Sdk\ImportInDev.proj" />
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <!-- clear the defaulted values from sdk-->
         <SelfContained>false</SelfContained>
+        <PublishTrimmed>false</PublishTrimmed>
+        <RuntimeIdentifier></RuntimeIdentifier>
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
@@ -30,6 +33,7 @@
         <ProjectReference Include="..\testapps\SimpleConsumer\SimpleConsumer.csproj" ReferenceOutputAssembly="false" />
         <ProjectReference Include="..\testapps\AppWithWitFolder\AppWithWitFolder.csproj" ReferenceOutputAssembly="false"/>
         <ProjectReference Include="..\testapps\OciWit\OciWit.csproj" ReferenceOutputAssembly="false"/>
+        <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM"/>
     </ItemGroup>
 
 </Project>

--- a/test/WasmComponentSdkTest/testapps/AppWithWitFolder/AppWithWitFolder.csproj
+++ b/test/WasmComponentSdkTest/testapps/AppWithWitFolder/AppWithWitFolder.csproj
@@ -5,17 +5,17 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
-        <InvariantGlobalization>true</InvariantGlobalization>
         <RuntimeIdentifier>wasi-wasm</RuntimeIdentifier>
         <TargetName>appwithwitfolder</TargetName>
     </PropertyGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\..\src\WasmComponent.Sdk\WasmComponent.Sdk.csproj" />
+        <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/test/WasmComponentSdkTest/testapps/OciWit/OciWit.csproj
+++ b/test/WasmComponentSdkTest/testapps/OciWit/OciWit.csproj
@@ -3,17 +3,17 @@
     <Import Project="..\..\..\..\src\WasmComponent.Sdk\ImportInDev.proj" />
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
-        <InvariantGlobalization>true</InvariantGlobalization>
         <RuntimeIdentifier>wasi-wasm</RuntimeIdentifier>
         <TargetName>ociwit</TargetName>
     </PropertyGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\..\..\..\src\WasmComponent.Sdk\WasmComponent.Sdk.csproj" />
+      <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/test/WasmComponentSdkTest/testapps/SimpleConsumer/SimpleConsumer.csproj
+++ b/test/WasmComponentSdkTest/testapps/SimpleConsumer/SimpleConsumer.csproj
@@ -5,7 +5,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -16,6 +16,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\..\src\WasmComponent.Sdk\WasmComponent.Sdk.csproj" />
+        <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM"/>
         
         <!-- Just to ensure build order -->
         <ProjectReference Include="..\SimpleProducer\SimpleProducer.csproj" ReferenceOutputAssembly="false" />

--- a/test/WasmComponentSdkTest/testapps/SimpleProducer/SimpleProducer.csproj
+++ b/test/WasmComponentSdkTest/testapps/SimpleProducer/SimpleProducer.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\src\WasmComponent.Sdk\ImportInDev.proj" />
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -16,6 +16,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\..\src\WasmComponent.Sdk\WasmComponent.Sdk.csproj" />
+        <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/test/WitBindgenTest/WitBindgenTest/WitBindgenTest.csproj
+++ b/test/WitBindgenTest/WitBindgenTest/WitBindgenTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/test/WitBindgenTest/testapps/LibraryUsingWit/LibraryUsingWit.csproj
+++ b/test/WitBindgenTest/testapps/LibraryUsingWit/LibraryUsingWit.csproj
@@ -3,13 +3,14 @@
     <Import Project="..\..\..\..\src\WitBindgen\ImportInDev.proj" />
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\..\..\..\src\WitBindgen\WitBindgen.csproj" />
+      <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
fixes https://github.com/bytecodealliance/componentize-dotnet/issues/55, follow up to #54 

Instead of creating a platform specific SDK package, instruct users to add extra package based on their platform.  Chose this route over creating platform specific version since we want to support Mono and those packages are not platform specific and it's pretty simple to add an additional dep. Also going to be looking into creating a template that will do it all for the user.

Also bumps a few versions and drop .8 from testing.