### PR TITLE
Fix so that compilation runs in correct order

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ wasmtime composed.wasm
 While you can run wasm-tools manually, you can also generate this automatically.  One way to do this is to [create a new project](./samples/calculator/CalculatorComposed/) and add the following:
 
 ```xml
- <Target Name="ComposeWasmComponent" AfterTargets="AfterBuild">
+ <Target Name="ComposeWasmComponent" AfterTargets="Publish">
         <PropertyGroup>
             <EntrypointComponent>../CalculatorHost/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/calculatorhost.wasm</EntrypointComponent>
             <DependencyComponent>../Adder/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/adder.wasm</DependencyComponent>

--- a/samples/calculator/CalculatorComposed/CalculatorComposed.csproj
+++ b/samples/calculator/CalculatorComposed/CalculatorComposed.csproj
@@ -16,7 +16,7 @@
       <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM"/>
     </ItemGroup>
 
-    <Target Name="ComposeWasmComponent" AfterTargets="AfterBuild">
+    <Target Name="ComposeWasmComponent" AfterTargets="Publish">
         <PropertyGroup>
             <EntrypointComponent>../CalculatorHost/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/CalculatorHost.wasm</EntrypointComponent>
             <DependencyComponent>../Adder/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/adder.wasm</DependencyComponent>

--- a/src/WasmComponent.Sdk/build/BytecodeAlliance.Componentize.DotNet.Wasm.SDK.targets
+++ b/src/WasmComponent.Sdk/build/BytecodeAlliance.Componentize.DotNet.Wasm.SDK.targets
@@ -1,6 +1,6 @@
 <Project>
-    <Target Name="EmitWasmOnBuild" AfterTargets="CopyFilesToOutputDirectory" DependsOnTargets="LinkNativeLlvm;"
-            Condition="'$(RuntimeIdentifier)' == 'wasi-wasm'">
-        <Message Importance="high" Text="Emit on build $(ProjectName) " />
-    </Target>
+    <!-- 
+        This links the publish step with the build so that when a user runs `dotnet build` they get a wasm file.
+     -->
+    <Target Name="PublishAfterBuild" AfterTargets="Build" DependsOnTargets="Publish" Condition="'$(RuntimeIdentifier)' == 'wasi-wasm'" />
 </Project>

--- a/test/E2ETest/testapps/E2EConsumer/E2EConsumer.csproj
+++ b/test/E2ETest/testapps/E2EConsumer/E2EConsumer.csproj
@@ -29,7 +29,7 @@
     </ItemGroup>
     
     <!-- After build, create the composed component so it can be executed in the test -->
-    <Target Name="ComposeWasmComponent" AfterTargets="AfterBuild">
+    <Target Name="ComposeWasmComponent" AfterTargets="Publish">
         <PropertyGroup>
             <DependencyComponent>../E2EProducer/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/e2eproducer.wasm</DependencyComponent>
         </PropertyGroup>

--- a/test/WasmComponentSdkTest/WasmComponentSdkTest/SimpleProducerConsumerTest.cs
+++ b/test/WasmComponentSdkTest/WasmComponentSdkTest/SimpleProducerConsumerTest.cs
@@ -49,7 +49,7 @@ public class SimpleProducerConsumerTest
     [Fact]
     public void CanBuildAppFromOci()
     {
-        var composed = FindModulePath("../testapps/OciWit", "ociwit.wasm");
+        var composed = FindModulePath($"../testapps/OciWit/bin/{Config}", "ociwit.wasm");
         var stdout = ExecuteCommandComponent(composed);
         Assert.StartsWith("Oci is awesome!", stdout);
     }
@@ -89,11 +89,18 @@ public class SimpleProducerConsumerTest
         }
 
         var matches = Directory.GetFiles(resolvedSearchDir, filename, SearchOption.AllDirectories);
-        if (matches.Count() != 1)
+        if (matches.Count() == 1)
         {
+            return Path.GetFullPath(matches.Single());
+        } 
+        else if (matches.Count() == 2 && matches.Any(x => Path.GetFullPath(x).Contains($"wasi-wasm\\native"))) {
+           return Path.GetFullPath(matches.First(x => Path.GetFullPath(x).Contains($"wasi-wasm\\native")));
+        }
+        else if (matches.Count() == 2 && matches.Any(x => Path.GetFullPath(x).Contains($"wasi-wasm/native"))) {
+           return Path.GetFullPath(matches.First(x => Path.GetFullPath(x).Contains($"wasi-wasm/native")));
+        }
+        else {
             throw new Exception($"Failed to get modules path, matched {matches.Count()} entries for directory {resolvedSearchDir} and filename {filename}.");
         }
-
-        return Path.GetFullPath(matches.Single());
     }
 }

--- a/test/WasmComponentSdkTest/testapps/SimpleConsumer/SimpleConsumer.csproj
+++ b/test/WasmComponentSdkTest/testapps/SimpleConsumer/SimpleConsumer.csproj
@@ -27,7 +27,7 @@
     </ItemGroup>
     
     <!-- After build, create the composed component so it can be executed in the test -->
-    <Target Name="ComposeWasmComponent" AfterTargets="AfterBuild">
+    <Target Name="ComposeWasmComponent" AfterTargets="Publish">
         <PropertyGroup>
             <DependencyComponent>../SimpleProducer/bin/$(Configuration)/$(TargetFramework)/wasi-wasm/native/simpleproducer.wasm</DependencyComponent>
         </PropertyGroup>


### PR DESCRIPTION
This fixes the issues where files are not linked in properly.  The build steps where brought in in the wrong order when `<Target Name="EmitWasmOnBuild" AfterTargets="CopyFilesToOutputDirectory" DependsOnTargets="LinkNativeLlvm;"`

See conversation in https://discord.com/channels/143867839282020352/1141126727028985877/1304883306063724624

