### PR TITLE
Don't overwrite the WitBindgenAddtionalArgs

### DIFF
--- a/src/WitBindgen/build/BytecodeAlliance.Componentize.DotNet.WitBindgen.targets
+++ b/src/WitBindgen/build/BytecodeAlliance.Componentize.DotNet.WitBindgen.targets
@@ -1,7 +1,6 @@
 ﻿<Project>
     <PropertyGroup>
         <WitBindgenRuntime>native-aot</WitBindgenRuntime>
-        <WitBindgenAddtionalArgs></WitBindgenAddtionalArgs>
 
         <!-- Keep this block all in sync manually, since URLs can be arbitrary -->
         <WasiSdkVersion>24.0</WasiSdkVersion>

--- a/test/E2ETest/testapps/E2EConsumer/E2EConsumer.csproj
+++ b/test/E2ETest/testapps/E2EConsumer/E2EConsumer.csproj
@@ -14,6 +14,7 @@
         <UseAppHost>false</UseAppHost>
         <PublishTrimmed>true</PublishTrimmed>
         <TargetName>e2econsumer</TargetName>
+        <WitBindgenAddtionalArgs>--features float-add</WitBindgenAddtionalArgs>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/E2ETest/testapps/E2EConsumer/Program.cs
+++ b/test/E2ETest/testapps/E2EConsumer/Program.cs
@@ -5,3 +5,8 @@ Console.WriteLine($"Hello, world on {RuntimeInformation.OSArchitecture}");
 
 var result = OperationsInterop.Add(123, 456);
 Console.WriteLine($"123 + 456 = {result}");
+
+// this is just here to make sure we can enable features and pass flags via WitBindgenAddtionalArgs
+// the fact that it compiles is enough to test this worked.
+var floatResult = OperationsInterop.AddFloat(1.1f, 1.2f);
+Console.WriteLine($"1.1 + 1.2 = {floatResult}");

--- a/test/E2ETest/testapps/E2EProducer/E2EProducer.csproj
+++ b/test/E2ETest/testapps/E2EProducer/E2EProducer.csproj
@@ -12,6 +12,7 @@
         <RuntimeIdentifier>wasi-wasm</RuntimeIdentifier>
         <PublishTrimmed>true</PublishTrimmed>
         <TargetName>e2eproducer</TargetName>
+        <WitBindgenAddtionalArgs>--features float-add</WitBindgenAddtionalArgs>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/E2ETest/testapps/E2EProducer/OperationsImpl.cs
+++ b/test/E2ETest/testapps/E2EProducer/OperationsImpl.cs
@@ -6,4 +6,9 @@ public class OperationsImpl : IOperations
     {
         return left + right;
     }
+
+    public static float AddFloat(float left, float right)
+    {
+        return left + right;
+    }
 }

--- a/test/E2ETest/testapps/E2EProducer/producer-consumer.wit
+++ b/test/E2ETest/testapps/E2EProducer/producer-consumer.wit
@@ -1,7 +1,9 @@
 package test:producer-consumer;
 
 interface operations {
-	add: func(left: s32, right: s32) -> s32;
+  add: func(left: s32, right: s32) -> s32;
+  @unstable(feature = float-add)
+  add-float: func(a: f32, b: f32) -> f32;
 }
 
 world producer {


### PR DESCRIPTION
fixes #77 

In addition this adds a test that runs outside the test framework with didn't catch this due the way the properties are imported