### PR TITLE
Fix tar on Windows

### DIFF
--- a/src/WasmComponent.Sdk/WasmComponent.Sdk.csproj
+++ b/src/WasmComponent.Sdk/WasmComponent.Sdk.csproj
@@ -29,6 +29,11 @@
         <IncludeBuildOutput>false</IncludeBuildOutput>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <TarPath Condition="'$(TarPath)' == '' and $([MSBuild]::IsOSPlatform('Windows'))">C:\Windows\System32\tar.exe</TarPath>
+        <TarPath Condition="'$(TarPath)' == ''">tar</TarPath>
+    </PropertyGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\WitBindgen\WitBindgen.csproj" PrivateAssets="None" />
     </ItemGroup>
@@ -96,7 +101,7 @@
     <Target Name="DownloadWasmTools" Inputs="@(PrebuiltWasmToolsOutputs)" Outputs="@(PrebuiltWasmToolsOutputs)">
         <DownloadFile SourceUrl="$(PrebuiltWasmToolsBaseUrl)-%(WasmToolsTarget.Identity)%(WasmToolsTarget.Ext)" DestinationFolder="tools\temp" DestinationFileName="%(WasmToolsTarget.Rid)%(WasmToolsTarget.Ext)" />
         <MakeDir Directories="tools\%(WasmToolsTarget.Rid)" />
-        <Exec Command="tar -xf &quot;temp/%(WasmToolsTarget.Rid)%(WasmToolsTarget.Ext)&quot; -C %(WasmToolsTarget.Rid) --strip-components=1" WorkingDirectory="tools" />
+        <Exec Command="$(TarPath) -xf &quot;temp/%(WasmToolsTarget.Rid)%(WasmToolsTarget.Ext)&quot; -C %(WasmToolsTarget.Rid) --strip-components=1" WorkingDirectory="tools" />
         <RemoveDir Directories="tools\temp" />
     </Target>
 

--- a/src/WasmComponent.Sdk/WasmComponent.Sdk.csproj
+++ b/src/WasmComponent.Sdk/WasmComponent.Sdk.csproj
@@ -30,7 +30,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TarPath Condition="'$(TarPath)' == '' and $([MSBuild]::IsOSPlatform('Windows'))">C:\Windows\System32\tar.exe</TarPath>
+        <TarPath Condition="'$(TarPath)' == '' and $([MSBuild]::IsOSPlatform('Windows'))">$(SystemRoot)\System32\tar.exe</TarPath>
         <TarPath Condition="'$(TarPath)' == ''">tar</TarPath>
     </PropertyGroup>
 

--- a/src/WitBindgen/WitBindgen.csproj
+++ b/src/WitBindgen/WitBindgen.csproj
@@ -33,6 +33,11 @@
         <IncludeBuildOutput>false</IncludeBuildOutput>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <TarPath Condition="'$(TarPath)' == '' and $([MSBuild]::IsOSPlatform('Windows'))">C:\Windows\System32\tar.exe</TarPath>
+        <TarPath Condition="'$(TarPath)' == ''">tar</TarPath>
+    </PropertyGroup>
+
     <ItemGroup>
         <None Include="../../Readme.md" Pack="true" PackagePath="\"/>
     </ItemGroup>
@@ -74,7 +79,7 @@
         <MakeDir Directories="tools\%(PrebuiltToolTarget.Rid)" />
         <DownloadFile SourceUrl="$(PrebuiltWitBindgenBaseUrl)-%(PrebuiltToolTarget.Identity)%(PrebuiltToolTarget.Ext)" DestinationFolder="tools\temp" DestinationFileName="%(PrebuiltToolTarget.Rid)%(PrebuiltToolTarget.Ext)" />
         <WriteLinesToFile File="$(CurrentWitBindgenVersion)" Lines="$(PrebuiltWitBindgenVersion)" Overwrite="true" WriteOnlyWhenDifferent="true" />
-        <Exec Command="tar -xf &quot;temp/%(PrebuiltToolTarget.Rid)%(PrebuiltToolTarget.Ext)&quot; -C %(PrebuiltToolTarget.Rid) --strip-components=1" WorkingDirectory="tools" />
+        <Exec Command="$(TarPath) -xf &quot;temp/%(PrebuiltToolTarget.Rid)%(PrebuiltToolTarget.Ext)&quot; -C %(PrebuiltToolTarget.Rid) --strip-components=1" WorkingDirectory="tools" />
         <RemoveDir Directories="tools\temp" />
 
         <DownloadFile SourceUrl="$(PrebuildWkgBaseUrl)-%(PrebuiltToolTarget.wkg)" DestinationFolder="tools\%(PrebuiltToolTarget.Rid)" DestinationFileName="wkg%(PrebuiltToolTarget.ExeExt)" />

--- a/src/WitBindgen/WitBindgen.csproj
+++ b/src/WitBindgen/WitBindgen.csproj
@@ -34,7 +34,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TarPath Condition="'$(TarPath)' == '' and $([MSBuild]::IsOSPlatform('Windows'))">C:\Windows\System32\tar.exe</TarPath>
+        <TarPath Condition="'$(TarPath)' == '' and $([MSBuild]::IsOSPlatform('Windows'))">$(SystemRoot)\System32\tar.exe</TarPath>
         <TarPath Condition="'$(TarPath)' == ''">tar</TarPath>
     </PropertyGroup>
 

--- a/src/WitBindgen/build/BytecodeAlliance.Componentize.DotNet.WitBindgen.targets
+++ b/src/WitBindgen/build/BytecodeAlliance.Componentize.DotNet.WitBindgen.targets
@@ -11,6 +11,11 @@
 
     </PropertyGroup>
 
+    <PropertyGroup>
+        <TarPath Condition="'$(TarPath)' == '' and $([MSBuild]::IsOSPlatform('Windows'))">C:\Windows\System32\tar.exe</TarPath>
+        <TarPath Condition="'$(TarPath)' == ''">tar</TarPath>
+    </PropertyGroup>
+
     <!--
         MSBuild stuff to acquire the necessary SDKs (WASI SDK) automatically. It will take a few mins on the
         first build on a given machine, but after that should no-op.
@@ -36,7 +41,7 @@
         <!-- Windows 10+ has tar built in, so this should work cross-platform -->
         <Message Importance="high" Text="Extracting @(WasiSdkDownloadTempFile) to $(WasiSdkRoot)..." />
         <MakeDir Directories="$(WasiSdkRoot)" />
-        <Exec Command="tar -xf &quot;@(WasiSdkDownloadTempFile)&quot; -C . --strip-components=1" WorkingDirectory="$(WasiSdkRoot)" />
+        <Exec Command="$(TarPath) -xf &quot;@(WasiSdkDownloadTempFile)&quot; -C . --strip-components=1" WorkingDirectory="$(WasiSdkRoot)" />
         <RemoveDir Directories="$(WasiSdkDownloadTempDir)" />
     </Target>
 

--- a/src/WitBindgen/build/BytecodeAlliance.Componentize.DotNet.WitBindgen.targets
+++ b/src/WitBindgen/build/BytecodeAlliance.Componentize.DotNet.WitBindgen.targets
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TarPath Condition="'$(TarPath)' == '' and $([MSBuild]::IsOSPlatform('Windows'))">C:\Windows\System32\tar.exe</TarPath>
+        <TarPath Condition="'$(TarPath)' == '' and $([MSBuild]::IsOSPlatform('Windows'))">$(SystemRoot)\System32\tar.exe</TarPath>
         <TarPath Condition="'$(TarPath)' == ''">tar</TarPath>
     </PropertyGroup>
 

--- a/test/WasmtimeCliFetcher/FetchWasmtime.targets
+++ b/test/WasmtimeCliFetcher/FetchWasmtime.targets
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TarPath Condition="'$(TarPath)' == '' and $([MSBuild]::IsOSPlatform('Windows'))">C:\Windows\System32\tar.exe</TarPath>
+        <TarPath Condition="'$(TarPath)' == '' and $([MSBuild]::IsOSPlatform('Windows'))">$(SystemRoot)\System32\tar.exe</TarPath>
         <TarPath Condition="'$(TarPath)' == ''">tar</TarPath>
     </PropertyGroup>
 

--- a/test/WasmtimeCliFetcher/FetchWasmtime.targets
+++ b/test/WasmtimeCliFetcher/FetchWasmtime.targets
@@ -17,12 +17,16 @@
         <WasmtimeUrl>https://github.com/bytecodealliance/wasmtime/releases/download/v$(WasmtimeVersion)/wasmtime-v$(WasmtimeVersion)-$(WasmtimeTarget)$(WasmtimeUrlExtension)</WasmtimeUrl>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <TarPath Condition="'$(TarPath)' == '' and $([MSBuild]::IsOSPlatform('Windows'))">C:\Windows\System32\tar.exe</TarPath>
+        <TarPath Condition="'$(TarPath)' == ''">tar</TarPath>
+    </PropertyGroup>
 
     <Target Name="AcquireWasmtime" Condition="!Exists('$(CurrentWasmtimeVersion)')" BeforeTargets="CoreBuild">
         <RemoveDir Directories="$(MSBuildThisFileDirectory)tools" />
         <DownloadFile SourceUrl="$(WasmtimeUrl)" DestinationFolder="$(MSBuildThisFileDirectory)tools" DestinationFileName="temp$(WasmtimeUrlExtension)" />	        
         <WriteLinesToFile File="$(CurrentWasmtimeVersion)" Lines="$(WasmtimeVersion)" Overwrite="true" WriteOnlyWhenDifferent="true" />
-        <Exec Command="tar -xf temp$(WasmtimeUrlExtension) --strip-components=1" WorkingDirectory="$(MSBuildThisFileDirectory)tools" />	  
+        <Exec Command="$(TarPath) -xf temp$(WasmtimeUrlExtension) --strip-components=1" WorkingDirectory="$(MSBuildThisFileDirectory)tools" />	  
         <Delete Files="$(MSBuildThisFileDirectory)tools\temp$(WasmtimeUrlExtension)" />
     </Target>
 </Project>


### PR DESCRIPTION
When the SDK doesn't exists in `$(WasiSdkRoot)` it's getting downloaded and extracted by `tar`.

However, I'm getting the following error when I run `dotnet build`
```
error MSB3073: The command "tar -xf "C:\Users\X\AppData\Local\Temp\51xb0ufs.jsz\wasi-sdk-24.0-x86_64-windows.tar.gz" -C . --strip-components=1" exited with code 128
```

This is because `tar` is overridden by Git on Windows on my machine:
```
$ where tar
C:\Program Files\Git\usr\bin\tar.exe
C:\Windows\System32\tar.exe
```

So, Git on Windows `tar` is being used, and for some reason, it doesn't work.

In this PR I've changed that the built-in Windows `tar.exe` is always used, which does work.

Not sure if this fixes the following issue: #87