### PR TITLE
Allow custom Wasi SDK version

### DIFF
--- a/src/WitBindgen/build/BytecodeAlliance.Componentize.DotNet.WitBindgen.targets
+++ b/src/WitBindgen/build/BytecodeAlliance.Componentize.DotNet.WitBindgen.targets
@@ -3,7 +3,7 @@
         <WitBindgenRuntime>native-aot</WitBindgenRuntime>
 
         <!-- Keep this block all in sync manually, since URLs can be arbitrary -->
-        <WasiSdkVersion>24.0</WasiSdkVersion>
+        <WasiSdkVersion Condition="'$(WasiSdkVersion)' == ''">24.0</WasiSdkVersion>
         <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('Windows'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$(WasiSdkVersion.Split(".")[0])/wasi-sdk-$(WasiSdkVersion)-x86_64-windows.tar.gz</WasiSdkUrl>
         <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('Linux'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$(WasiSdkVersion.Split(".")[0])/wasi-sdk-$(WasiSdkVersion)-x86_64-linux.tar.gz</WasiSdkUrl>
         <WasiSdkUrl Condition="$([MSBuild]::IsOSPlatform('OSX'))">https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$(WasiSdkVersion.Split(".")[0])/wasi-sdk-$(WasiSdkVersion)-x86_64-macos.tar.gz</WasiSdkUrl>


### PR DESCRIPTION
This PR allows a custom WASI SDK version to be set.

The latest NativeAOT-LLVM only supports WASI SDK 25.0, however, there is currently no way to change this version in the project.
With this change you can add the following to your project:

```xml
<WasiSdkVersion>25.0</WasiSdkVersion>
```