### PR TITLE
Add library project template (componentize.wasi.lib)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,12 +39,15 @@ jobs:
       run: |
         ls ./artifacts/*.nupkg
         version=$(unzip -p ./artifacts/*SDK*.nupkg '*.nuspec' | grep -oE "<version>[^<]+" | sed 's/<version>//' | grep -oE "^[0-9]+\.[0-9]+\.[0-9]+-preview")
-        template_version=$(grep -oE "Version=\"[^\"]+" ./templates/content/wasi-cli/wasi-cli.csproj | sed 's/Version="//' | grep -oE "^[0-9]+\.[0-9]+\.[0-9]+-preview")
-        echo "Package Version: $version | Template version: $template_version"
-        if [ "$version" != "$template_version" ]; then 
-          echo "Version mismatch: Package version ($version) does not match template version ($template_version)";
-          exit 1; 
-        fi
+        for dir in ./templates/content/*/; do
+          template=$(basename $dir)
+          template_version=$(grep -oE "Version=\"[^\"]+" $dir$template.csproj | sed 's/Version="//' | grep -oE "^[0-9]+\.[0-9]+\.[0-9]+-preview")
+          echo "Package Version: $version | Template $template version: $template_version"
+          if [ "$version" != "$template_version" ]; then
+            echo "Version mismatch: Package version ($version) does not match template $template version ($template_version)";
+            exit 1;
+          fi
+        done
     - name: Test Template
       shell: bash
       run: |
@@ -54,6 +57,12 @@ jobs:
         pushd $RUNNER_TEMP/projects
         dotnet new componentize.wasi.cli -o test
         cd test
+        dotnet nuget add source $artifact_dir
+        dotnet build
+        dotnet list package
+        cd ..
+        dotnet new componentize.wasi.lib -o TestLib
+        cd TestLib
         dotnet nuget add source $artifact_dir
         dotnet build
         dotnet list package

--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ Hello world from compontize-dotnet!
 
 (if needed, replace `MyApp` with the actual name of your project)
 
+### Library components
+
+If you want to build a library component that exports functionality via WIT instead of a command line application, use the library template:
+
+```bash
+dotnet new componentize.wasi.lib -o MyLib
+dotnet build MyLib
+```
+
+The generated project contains a `component.wit` file with an exported interface and a corresponding implementation class. See [Creating a WASI 0.2 component, including WIT support](#creating-a-wasi-02-component-including-wit-support) below for how to customize it.
+
 ## Creating a WASI 0.2 component, including WIT support
 Lastest version of NativeAOT compiler package and the mono support in dotnet 9-preview 7 build native wasi 0.2 components with no additional tools.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,7 @@
 1. Update all the tool versions in [Directory.Build.Props](./Directory.Build.props)
 1. Open a PR to update:
     - the `<VersionPrefix>` tag in [Directory.Build.Props](./Directory.Build.props)
-    - the `BytecodeAlliance.Componentize.DotNet.Wasm.SDK` package `version` to match the `<VersionPrefix>` in the [template](./templates/content/wasi-cli/wasi-cli.csproj). For example the template version might look like `Version="0.6.0-preview*"`. This ensures the templates use the latest package.
+    - the `BytecodeAlliance.Componentize.DotNet.Wasm.SDK` package `version` to match the `<VersionPrefix>` in each template under [templates/content](./templates/content/) ([wasi-cli](./templates/content/wasi-cli/wasi-cli.csproj) and [wasi-lib](./templates/content/wasi-lib/wasi-lib.csproj)). For example the template version might look like `Version="0.6.0-preview*"`. This ensures the templates use the latest package.
 1. Maintainers approve and merge PR
 1. After the PR merges a maintainer triggers the Release workflow on the main branch via the github Actions UI or runs:
 

--- a/templates/content/wasi-lib/.template.config/template.json
+++ b/templates/content/wasi-lib/.template.config/template.json
@@ -4,12 +4,12 @@
   "classifications": [
     "wasi",
     "wasm",
-    "Console"
+    "Library"
   ],
-  "identity": "BytecodeAlliance.Componentize.DotNet.Templates.Console",
-  "name": "Componentize-dotnet wasi console template",
-  "shortName": "componentize.wasi.cli",
-  "sourceName": "wasi-cli",
+  "identity": "BytecodeAlliance.Componentize.DotNet.Templates.Library",
+  "name": "Componentize-dotnet wasi library template",
+  "shortName": "componentize.wasi.lib",
+  "sourceName": "wasi-lib",
   "tags": {
     "language": "C#",
     "type": "project"

--- a/templates/content/wasi-lib/OperationsImpl.cs
+++ b/templates/content/wasi-lib/OperationsImpl.cs
@@ -1,0 +1,9 @@
+namespace LibraryWorld.wit.exports.example.component;
+
+public class OperationsImpl : IOperations
+{
+    public static int Add(int left, int right)
+    {
+        return left + right;
+    }
+}

--- a/templates/content/wasi-lib/component.wit
+++ b/templates/content/wasi-lib/component.wit
@@ -1,0 +1,9 @@
+package example:component;
+
+interface operations {
+  add: func(left: s32, right: s32) -> s32;
+}
+
+world library {
+  export operations;
+}

--- a/templates/content/wasi-lib/nuget.config
+++ b/templates/content/wasi-lib/nuget.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-experimental" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json" />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/templates/content/wasi-lib/wasi-lib.csproj
+++ b/templates/content/wasi-lib/wasi-lib.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>wasi_lib</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RuntimeIdentifier>wasi-wasm</RuntimeIdentifier>
+    <UseAppHost>false</UseAppHost>
+    <PublishTrimmed>true</PublishTrimmed>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BytecodeAlliance.Componentize.DotNet.Wasm.SDK" Version="0.7.0-preview*" />
+    <PackageReference Condition="'$(platform)' == 'Windows_NT'" Include="runtime.win-x64.microsoft.dotnet.ilcompiler.llvm" Version="10.0.0-alpha.1.25162.1" />
+    <PackageReference Condition="'$(platform)' == 'linux'" Include="runtime.linux-x64.microsoft.dotnet.ilcompiler.llvm" Version="10.0.0-alpha.1.25162.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Wit Update="component.wit" World="library" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes #85

Adds a `componentize.wasi.lib` template for creating a library component that exports functionality via WIT, alongside the existing `componentize.wasi.cli` console template. The generated project follows the same pattern as `samples/calculator/Adder`: a `component.wit` exporting an `operations` interface and a corresponding implementation class.

Other changes:
- CI builds the new template in the template test, and the package/template version-match check now loops over every template under `templates/content/`
- RELEASE.md mentions both template csproj files in the version bump step
- README documents the new template

Verified locally on Windows: `dotnet new componentize.wasi.lib -o TestLib` builds with 0 warnings, and `wasm-tools component wit` on the output shows `export example:component/operations`.