### PR TITLE
Prepare 0.8.0 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>0.7.0</VersionPrefix>
+        <VersionPrefix>0.8.0</VersionPrefix>
         <VersionSuffix Condition="'$(BuildNumber)' == ''">dev</VersionSuffix>
         <VersionSuffix Condition="'$(BuildNumber)' != ''">preview$([System.String]::Format('{0:00000}', $([MSBuild]::Add($(BuildNumber), 0))))</VersionSuffix>
         <PackageVersion>$(VersionPrefix)-$(VersionSuffix)</PackageVersion>

--- a/templates/content/wasi-cli/wasi-cli.csproj
+++ b/templates/content/wasi-cli/wasi-cli.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BytecodeAlliance.Componentize.DotNet.Wasm.SDK" Version="0.7.0-preview*" />
+    <PackageReference Include="BytecodeAlliance.Componentize.DotNet.Wasm.SDK" Version="0.8.0-preview*" />
     <PackageReference Condition="'$(platform)' == 'Windows_NT'" Include="runtime.win-x64.microsoft.dotnet.ilcompiler.llvm" Version="10.0.0-rc.1.26306.1" />
     <PackageReference Condition="'$(platform)' == 'linux'" Include="runtime.linux-x64.microsoft.dotnet.ilcompiler.llvm" Version="10.0.0-rc.1.26306.1" />
   </ItemGroup>

--- a/templates/content/wasi-lib/wasi-lib.csproj
+++ b/templates/content/wasi-lib/wasi-lib.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BytecodeAlliance.Componentize.DotNet.Wasm.SDK" Version="0.7.0-preview*" />
+    <PackageReference Include="BytecodeAlliance.Componentize.DotNet.Wasm.SDK" Version="0.8.0-preview*" />
     <PackageReference Condition="'$(platform)' == 'Windows_NT'" Include="runtime.win-x64.microsoft.dotnet.ilcompiler.llvm" Version="10.0.0-rc.1.26306.1" />
     <PackageReference Condition="'$(platform)' == 'linux'" Include="runtime.linux-x64.microsoft.dotnet.ilcompiler.llvm" Version="10.0.0-rc.1.26306.1" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Bump the package `VersionPrefix` to `0.8.0`.
- Update the WASI CLI and library templates to reference `BytecodeAlliance.Componentize.DotNet.Wasm.SDK` as `0.8.0-preview*`.
- Keep the already-current release tool pins in `Directory.Build.props` unchanged.