### PR TITLE
Update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,9 @@ jobs:
         dotnet: [ '10.x']
         os: [ubuntu-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
       with:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Restore dependencies
@@ -76,4 +76,3 @@ jobs:
         path: artifacts/*.nupkg
         if-no-files-found: error
       if: ${{ matrix.dotnet  == '10.x' && matrix.os == 'windows-latest' }}
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,9 @@ jobs:
     name: Release
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     steps:
-    - uses: actions/checkout@v4 # needed for the create release step
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6; needed for the create release step
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
       with:
         dotnet-version: 10.x
     - name: Download artifacts


### PR DESCRIPTION
GitHub Actions is deprecating Node.js 20 for JavaScript actions, so this updates the workflows before the runner default changes to Node.js 24.

This updates the build and release workflows from `actions/checkout@v4` and `actions/setup-dotnet@v4` to Node 24-compatible releases, pinned to the commit SHAs for `checkout` v6 and `setup-dotnet` v5. Version comments are kept next to the hashes so reviewers can identify the pinned action versions.